### PR TITLE
Fix documentation of `stamp_changelog`

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ update_changelog(
 ```
  
 ### stamp_changelog
-Stamps the _Unreleased_ (see [How can I minimize the effort required?](http://keepachangelog.com/)) section with provided identifier in your project `CHANGELOG.md` file. 
+Stamps the _Unreleased_ (see [How can I minimize the effort required?](http://keepachangelog.com/)) section with provided identifier in your project `CHANGELOG.md` file and sets up a new _Unreleased_ section above it.
 Additionally, you can provide git tag associated with this section. `stamp_changelog` will then create a link to diff between this and previous section's tag on Github. This will enable you to quickly get to [comparison between two tags](https://help.github.com/articles/comparing-commits-across-time/).
 ``` ruby
 stamp_changelog(


### PR DESCRIPTION
At least according to
https://github.com/dusek/fastlane-plugin-changelog/blob/master/lib/fastlane/plugin/changelog/actions/stamp_changelog.rb#L16,
`stamp_changelog` does set up a new "Unreleased" section above the
stamped one. That is what most people will want. So provide them with
relief in the docs that that is indeed what they will get.