### PR TITLE
Fix stamp_changelog action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed:
+- Fix stamp_changelog action
+
 ## [0.6.0] - 2015-12-10
 ### Added
 - New [emojify action](https://github.com/pajapro/fastlane-plugin-changelog/blob/master/README.md#-emojify_changelog)

--- a/Dangerfile
+++ b/Dangerfile
@@ -10,9 +10,9 @@ warn("Big PR") if git.lines_of_code > 500
 # Request a CHANGELOG entry, and give an example
 has_app_changes = !git.modified_files.grep(/lib/).empty?
 if !git.modified_files.include?('CHANGELOG.md') && has_app_changes
-  fail("Please include a CHANGELOG entry to credit yourself! \nYou can find it at [CHANGELOG.md](https://github.com/pajapro/fastlane-plugin-changelog/blob/master/CHANGELOG.md).", :sticky => false)
+  fail("Please include a CHANGELOG entry to credit yourself! \nYou can find it at [CHANGELOG.md](https://github.com/pajapro/fastlane-plugin-changelog/blob/#{github.branch_for_head}/CHANGELOG.md).", :sticky => false)
   markdown <<-MARKDOWN
-Here's an example of your CHANGELOG entry under [Unreleased] section:
+Here's an example of your CHANGELOG entry under [`[Unreleased]`](https://github.com/pajapro/fastlane-plugin-changelog/blob/#{github.branch_for_head}/CHANGELOG.md#unreleased) section:
 ```markdown
 ### Fixed:
 - #{github.pr_title}

--- a/lib/fastlane/plugin/changelog/actions/stamp_changelog.rb
+++ b/lib/fastlane/plugin/changelog/actions/stamp_changelog.rb
@@ -9,7 +9,7 @@ module Fastlane
         UI.error("CHANGELOG.md at path '#{changelog_path}' does not exist") unless File.exist?(changelog_path)
 
         # 2. Ensure there are changes in [Unreleased] section
-        unreleased_section_content = Actions::ReadChangelogAction.run(changelog_path: changelog_path, section_identifier: UNRELEASED_IDENTIFIER)
+        unreleased_section_content = Actions::ReadChangelogAction.run(changelog_path: changelog_path, section_identifier: UNRELEASED_IDENTIFIER, excluded_markdown_elements: ["###"])
         if unreleased_section_content.eql?("\n")
           UI.important("WARNING: No changes in [Unreleased] section to stamp!")
         else

--- a/lib/fastlane/plugin/changelog/version.rb
+++ b/lib/fastlane/plugin/changelog/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Changelog
-    VERSION = "0.6.0"
+    VERSION = "0.6.1"
   end
 end


### PR DESCRIPTION
[stamp_changelog](https://github.com/pajapro/fastlane-plugin-changelog/tree/fix-excluded-markdown#--stamp_changelog) actions uses [read_changelog](https://github.com/pajapro/fastlane-plugin-changelog/tree/fix-excluded-markdown#--read_changelog) under the hood in order to ensure there are changes in the `[Unreleased]` section.

Unfortunately, [executing action](https://github.com/pajapro/fastlane-plugin-changelog/blob/master/lib/fastlane/plugin/changelog/actions/stamp_changelog.rb#L12) directly from another action [does not implicitly load](https://docs.fastlane.tools/advanced/#run-actions-directly) the [default param](https://github.com/pajapro/fastlane-plugin-changelog/blob/master/lib/fastlane/plugin/changelog/actions/read_changelog.rb#L95-L100). 

Therefore, in this PR I pass in the default excluded markdown element `###` (subheader). 