### PR TITLE
Properly escape section identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed:
+- Properly escape section identifiers [PR #18](https://github.com/pajapro/fastlane-plugin-changelog/pull/18) by [PromptWorks](https://www.promptworks.com/)
 
 ## [0.6.1] - 2016-01-17
 ### Fixed:

--- a/lib/fastlane/plugin/changelog/actions/read_changelog.rb
+++ b/lib/fastlane/plugin/changelog/actions/read_changelog.rb
@@ -11,7 +11,7 @@ module Fastlane
         UI.error("CHANGELOG.md at path '#{changelog_path}' does not exist") unless File.exist?(changelog_path)
 
         section_identifier = params[:section_identifier] unless params[:section_identifier].to_s.empty?
-        escaped_section_identifier = section_identifier[/\[(.*?)\]/, 1]
+        escaped_section_identifier = Regexp.escape(section_identifier[/\[(.*?)\]/, 1])
 
         excluded_markdown_elements = params[:excluded_markdown_elements]
 

--- a/spec/fixtures/CHANGELOG_MOCK.md
+++ b/spec/fixtures/CHANGELOG_MOCK.md
@@ -67,7 +67,7 @@ both "open" and "closed" source projects equally.
 ### Deprecated
 - Obsolete contact screen
 
-## [0.0.5] - 2014-08-09
+## [0.0.5 (rc1)] - 2014-08-09
 ### Added
 - Markdown links to version tags on release headings.
 - Unreleased section to gather unreleased changes and encourage note

--- a/spec/read_changelog_action_spec.rb
+++ b/spec/read_changelog_action_spec.rb
@@ -1,7 +1,7 @@
 describe Fastlane::Actions::ReadChangelogAction do
   describe 'Read CHANGELOG.md action' do
     let (:changelog_mock_path) { "./spec/fixtures/CHANGELOG_MOCK.md" }
-    let (:existing_section_identifier) { '[0.0.5]' }
+    let (:existing_section_identifier) { '[0.0.5 (rc1)]' }
 
     it 'reads content of [Unreleased] section' do
       result = Fastlane::FastFile.new.parse("lane :test do


### PR DESCRIPTION
Our section identifiers contain some parentheses. It's important to escape strings when you interpolate them into regular expressions anyway.