### PR TITLE
Exclude/Preserve placeholder line in stamp_changelog action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- Add `placeholder_line` param to `stamp_changelog` action ([feature request #22](https://github.com/pajapro/fastlane-plugin-changelog/issues/22))
 
 ## [0.8.0] - 2017-11-11
 ### Fixed:

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ stamp_changelog(
 )
 ```
 
+🤖 Moreover, if you are using [danger-changelog](https://github.com/dblock/danger-changelog) plugin, you can leverage `placeholder_line` string paramater. `placeholder_line` string will be ignored when stamping an existing section _and_ copied into `[Unreleased]` section. This will help contributors to your project to see where changelog changes should be added (see [feature request](https://github.com/pajapro/fastlane-plugin-changelog/issues/22)). 
+
 ### 😁 emojify_changelog
 Emojifies the output of `read_changelog` action. When you share changelog with the rest of your team on e.g.: Slack channel, it's nice to sprinkle your subsections with a bit of visuals so it immediately catches eyes of your teammates. `emojify_changelog` uses the output of `read_changelog` action to append an emoji to known subsections, for example:
 

--- a/lib/fastlane/plugin/changelog/actions/stamp_changelog.rb
+++ b/lib/fastlane/plugin/changelog/actions/stamp_changelog.rb
@@ -16,12 +16,13 @@ module Fastlane
           section_identifier = params[:section_identifier] unless params[:section_identifier].to_s.empty?
           stamp_date = params[:stamp_date]
           git_tag = params[:git_tag]
+          placeholder_line = params[:placeholder_line]
 
-          stamp(changelog_path, section_identifier, stamp_date, git_tag)
+          stamp(changelog_path, section_identifier, stamp_date, git_tag, placeholder_line)
         end
       end
 
-      def self.stamp(changelog_path, section_identifier, stamp_date, git_tag)
+      def self.stamp(changelog_path, section_identifier, stamp_date, git_tag, placeholder_line)
         # 1. Update [Unreleased] section with given identifier
         Actions::UpdateChangelogAction.run(changelog_path: changelog_path,
                                           section_identifier: UNRELEASED_IDENTIFIER,
@@ -37,7 +38,14 @@ module Fastlane
             # Find the first section identifier
             if !inserted_unreleased && line =~ /\#{2}\s?\[(.*?)\]/
               unreleased_section = "## [Unreleased]"
-              line = "#{unreleased_section}\n\n#{line}"
+
+              # Insert placeholder line (if provided)
+              if !placeholder_line.nil? && !placeholder_line.empty?
+                line = "#{unreleased_section}\n#{placeholder_line}\n\n#{line}"
+              else 
+                line = "#{unreleased_section}\n\n#{line}"
+              end  
+              
               inserted_unreleased = true
 
               UI.message("Created [Unreleased] placeholder section")
@@ -116,6 +124,11 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :git_tag,
                                        env_name: "FL_STAMP_CHANGELOG_GIT_TAG",
                                        description: "The git tag associated with this section",
+                                       is_string: true,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :placeholder_line,
+                                       env_name: "FL_STAMP_CHANGELOG_PLACEHOLDER_LINE",
+                                       description: "The placeholder line to be excluded in stamped section and added to [Unreleased] section",
                                        is_string: true,
                                        optional: true)
         ]

--- a/lib/fastlane/plugin/changelog/actions/stamp_changelog.rb
+++ b/lib/fastlane/plugin/changelog/actions/stamp_changelog.rb
@@ -27,7 +27,8 @@ module Fastlane
         Actions::UpdateChangelogAction.run(changelog_path: changelog_path,
                                           section_identifier: UNRELEASED_IDENTIFIER,
                                           updated_section_identifier: section_identifier,
-                                          append_date: stamp_date)
+                                          append_date: stamp_date,
+                                          excluded_placeholder_line: placeholder_line)
 
         file_content = ""
 

--- a/spec/fixtures/CHANGELOG_MOCK_PLACEHOLDER_SUPPORT.md
+++ b/spec/fixtures/CHANGELOG_MOCK_PLACEHOLDER_SUPPORT.md
@@ -1,0 +1,120 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning](http://semver.org/).
+
+## [Unreleased]
+* Your contribution here.
+
+### Added
+* New awesome feature.
+
+## [0.3.0] - 2015-12-03
+### Added
+* RU translation from @aishek.
+* pt-BR translation from @tallesl.
+* es-ES translation from @ZeliosAriex.
+
+## [0.2.0] - 2015-10-06
+### Changed
+* Remove exclusionary mentions of "open source" since this project can benefit
+both "open" and "closed" source projects equally.
+
+## [0.1.0] - 2015-10-06
+### Added
+* Answer "Should you ever rewrite a change log?".
+
+### Changed
+* Improve argument against commit logs.
+* Start following [SemVer](http://semver.org) properly.
+
+## [0.0.8] - 2015-02-17
+### Changed
+* Update year to match in every README example.
+* Reluctantly stop making fun of Brits only, since most of the world
+  writes dates in a strange way.
+
+### Fixed
+* Fix typos in recent README changes.
+* Update outdated unreleased diff link.
+
+## [0.0.7] - 2015-02-16
+### Added
+* Link, and make it obvious that date format is ISO 8601.
+
+### Changed
+* Clarified the section on "Is there a standard change log format?".
+
+### Fixed
+* Fix Markdown links to tag comparison URL with footnote-style links.
+
+## [0.0.6] - 2014-12-12
+### Added
+* New awesome feature
+
+### Changed
+* Onboarding flow
+
+### Fixed
+* Fix Markdown links
+
+### Removed
+* User tracking
+
+### Work In Progress
+* Sales screen
+
+### Security
+* Enable SSL pinning
+
+### Deprecated
+* Obsolete contact screen
+
+## [0.0.5 (rc1)] - 2014-08-09
+### Added
+* Markdown links to version tags on release headings.
+* Unreleased section to gather unreleased changes and encourage note
+keeping prior to releases.
+
+## [0.0.4] - 2014-08-09
+### Added
+* Better explanation of the difference between the file ("CHANGELOG")
+and its function "the change log".
+
+### Changed
+* Refer to a "change log" instead of a "CHANGELOG" throughout the site
+to differentiate between the file and the purpose of the file — the
+logging of changes.
+
+### Removed
+* Remove empty sections from CHANGELOG, they occupy too much space and
+create too much noise in the file. People will have to assume that the
+missing sections were intentionally left out because they contained no
+notable changes.
+
+## [0.0.3] - 2014-08-09
+### Added
+* "Why should I care?" section mentioning The Changelog podcast.
+
+## [0.0.2] - 2014-07-10
+### Added
+* Explanation of the recommended reverse chronological release ordering.
+
+## 0.0.1 - 2014-05-31
+### Added
+* This CHANGELOG file to hopefully serve as an evolving example of a standardized open source project CHANGELOG.
+* CNAME file to enable GitHub Pages custom domain
+* README now contains answers to common questions about CHANGELOGs
+* Good examples and basic guidelines, including proper date formatting.
+* Counter-examples: "What makes unicorns cry?"
+
+[Unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.8...v0.1.0
+[0.0.8]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.7...v0.0.8
+[0.0.7]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.6...v0.0.7
+[0.0.6]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.5...v0.0.6
+[0.0.5]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.4...v0.0.5
+[0.0.4]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.3...v0.0.4
+[0.0.3]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.2...v0.0.3
+[0.0.2]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.1...v0.0.2

--- a/spec/fixtures/CHANGELOG_MOCK_PLACEHOLDER_SUPPORT.md
+++ b/spec/fixtures/CHANGELOG_MOCK_PLACEHOLDER_SUPPORT.md
@@ -99,7 +99,7 @@ notable changes.
 ### Added
 * Explanation of the recommended reverse chronological release ordering.
 
-## 0.0.1 - 2014-05-31
+## [0.0.1] - 2014-05-31
 ### Added
 * This CHANGELOG file to hopefully serve as an evolving example of a standardized open source project CHANGELOG.
 * CNAME file to enable GitHub Pages custom domain

--- a/spec/stamp_changelog_action_with_placeholder_action_spec.rb
+++ b/spec/stamp_changelog_action_with_placeholder_action_spec.rb
@@ -1,0 +1,128 @@
+describe Fastlane::Actions::StampChangelogAction do
+  describe 'Stamp CHANGELOG.md with placeholder line action' do
+    let (:changelog_mock_path) { './../spec/fixtures/CHANGELOG_MOCK_PLACEHOLDER_SUPPORT.md' }
+    let (:changelog_mock_path_hook) { './spec/fixtures/CHANGELOG_MOCK_PLACEHOLDER_SUPPORT.md' } # Path to mock CHANGELOG.md with format for placeholders support in [Unreleased] section (https://github.com/dblock/danger-changelog)
+    let (:updated_section_identifier) { '12.34.56' }
+    let (:placeholder_line) { '* Your contribution here.' }
+
+    before(:each) do
+      @original_content = File.read(changelog_mock_path_hook)
+    end
+
+    after(:each) do
+      File.open(changelog_mock_path_hook, 'w') { |f| f.write(@original_content) }
+    end
+
+    it 'rejects to stamp empty [Unreleased] section' do
+      expect(FastlaneCore::UI).to receive(:important).with("WARNING: No changes in [Unreleased] section to stamp!")
+
+      # Stamp [Unreleased] with given section identifier
+      Fastlane::FastFile.new.parse("lane :test do
+          stamp_changelog(changelog_path: '#{changelog_mock_path}',
+                          section_identifier: '#{updated_section_identifier}')
+          end").runner.execute(:test)
+
+      # Try to stamp [Unreleased] section again, while [Unreleased] section is actually empty
+      Fastlane::FastFile.new.parse("lane :test do
+          stamp_changelog(changelog_path: '#{changelog_mock_path}',
+                          section_identifier: '#{updated_section_identifier}')
+          end").runner.execute(:test)
+    end
+
+    context "stamps [Unreleased] section with given identifier" do
+
+      it 'creates a new section identifier with provided identifier' do
+        # Read what's in [Unreleased]
+        read_result = Fastlane::FastFile.new.parse("lane :test do
+            read_changelog(changelog_path: '#{changelog_mock_path}')
+          end").runner.execute(:test)
+
+        # Stamp [Unreleased] with given section identifier
+        Fastlane::FastFile.new.parse("lane :test do
+            stamp_changelog(changelog_path: '#{changelog_mock_path}',
+                           section_identifier: '#{updated_section_identifier}')
+        end").runner.execute(:test)
+
+        # Read updated section
+        post_stamp_read_result = Fastlane::FastFile.new.parse("lane :test do
+            read_changelog(changelog_path: '#{changelog_mock_path}',
+                           section_identifier: '[#{updated_section_identifier}]')
+          end").runner.execute(:test)
+
+        expect(read_result).to eq(post_stamp_read_result)
+      end
+
+      it 'creates an empty [Unreleased] section' do
+        # Stamp [Unreleased] with given section identifier
+        Fastlane::FastFile.new.parse("lane :test do
+            stamp_changelog(changelog_path: '#{changelog_mock_path}',
+                            section_identifier: '#{updated_section_identifier}')
+            end").runner.execute(:test)
+
+        # Read what's in [Unreleased]
+        read_result = Fastlane::FastFile.new.parse("lane :test do
+            read_changelog(changelog_path: '#{changelog_mock_path}')
+          end").runner.execute(:test)
+
+        expect(read_result).to eq("")
+      end    
+
+      it 'excludes placeholder line' do
+        # Stamp [Unreleased] with given section identifier and excludes placeholder line
+        Fastlane::FastFile.new.parse("lane :test do
+            stamp_changelog(changelog_path: '#{changelog_mock_path}',
+                            section_identifier: '#{updated_section_identifier}',
+                            placeholder_line: '#{placeholder_line}')
+            end").runner.execute(:test)      
+        
+        # Read updated section
+        post_stamp_read_result = Fastlane::FastFile.new.parse("lane :test do
+            read_changelog(changelog_path: '#{changelog_mock_path}',
+                           section_identifier: '[#{updated_section_identifier}]')
+          end").runner.execute(:test)
+
+        expect(post_stamp_read_result).to eq("Added\n* New awesome feature.")
+      end
+
+      it 'adds placeholder line to [Unreleased] section after stamping' do
+        # Stamp [Unreleased] with given section identifier and provided placeholder line
+        Fastlane::FastFile.new.parse("lane :test do
+            stamp_changelog(changelog_path: '#{changelog_mock_path}',
+                            section_identifier: '#{updated_section_identifier}',
+                            placeholder_line: '#{placeholder_line}')
+            end").runner.execute(:test)      
+        
+        # Read updated section
+        read_result = Fastlane::FastFile.new.parse("lane :test do
+            read_changelog(changelog_path: '#{changelog_mock_path}')
+          end").runner.execute(:test)
+
+        expect(read_result).to eq("* Your contribution here.")
+      end
+
+      # Combination of the 2 above tests
+      it '1. excludes placeholder line in stamped section and 2. adds placeholder line into [Unreleased] section' do
+        # Stamp [Unreleased] with given section identifier and excludes placeholder line
+        Fastlane::FastFile.new.parse("lane :test do
+            stamp_changelog(changelog_path: '#{changelog_mock_path}',
+                            section_identifier: '#{updated_section_identifier}',
+                            placeholder_line: '#{placeholder_line}')
+            end").runner.execute(:test)      
+        
+        # Read updated section
+        stamped_section_read_result = Fastlane::FastFile.new.parse("lane :test do
+            read_changelog(changelog_path: '#{changelog_mock_path}',
+                           section_identifier: '[#{updated_section_identifier}]')
+          end").runner.execute(:test)
+
+        unreleased_section_read_result = Fastlane::FastFile.new.parse("lane :test do
+            read_changelog(changelog_path: '#{changelog_mock_path}')
+          end").runner.execute(:test)
+
+        expect(stamped_section_read_result).to eq("Added\n* New awesome feature.")
+        expect(stamped_section_read_result =~ /^#{placeholder_line}/).to be_falsey
+        expect(unreleased_section_read_result).to eq("* Your contribution here.")
+      end
+    end    
+  end
+end

--- a/spec/update_changelog_action_spec.rb
+++ b/spec/update_changelog_action_spec.rb
@@ -13,7 +13,7 @@ describe Fastlane::Actions::UpdateChangelogAction do
       File.open(changelog_mock_path_hook, 'w') { |f| f.write(@original_content) }
     end
 
-    it 'udpates [Unreleased] section identifier' do
+    it 'updates [Unreleased] section identifier' do
       # Read what's in [Unreleased]
       read_result = Fastlane::FastFile.new.parse("lane :test do
           read_changelog(changelog_path: '#{changelog_mock_path}')
@@ -34,7 +34,7 @@ describe Fastlane::Actions::UpdateChangelogAction do
       expect(read_result).to eq(post_update_read_result)
     end
 
-    it 'udpates specific section identifier' do
+    it 'updates specific section identifier' do
       # Read what's in [Unreleased]
       read_result = Fastlane::FastFile.new.parse("lane :test do
           read_changelog(changelog_path: '#{changelog_mock_path}',

--- a/spec/update_changelog_action_spec.rb
+++ b/spec/update_changelog_action_spec.rb
@@ -14,12 +14,12 @@ describe Fastlane::Actions::UpdateChangelogAction do
     end
 
     it 'updates [Unreleased] section identifier' do
-      # Read what's in [Unreleased]
+      # Read what's in [Unreleased] section
       read_result = Fastlane::FastFile.new.parse("lane :test do
           read_changelog(changelog_path: '#{changelog_mock_path}')
         end").runner.execute(:test)
 
-      # Update [Unreleased] with another section identifier
+      # Update [Unreleased] section identifier with new one
       Fastlane::FastFile.new.parse("lane :test do
        	update_changelog(changelog_path: '#{changelog_mock_path}',
                           updated_section_identifier: '#{updated_section_identifier}')
@@ -35,13 +35,13 @@ describe Fastlane::Actions::UpdateChangelogAction do
     end
 
     it 'updates specific section identifier' do
-      # Read what's in [Unreleased]
+      # Read what's in specified section
       read_result = Fastlane::FastFile.new.parse("lane :test do
           read_changelog(changelog_path: '#{changelog_mock_path}',
                          section_identifier: '#{existing_section_identifier}')
         end").runner.execute(:test)
 
-      # Update given section identifier with another one
+      # Update given section identifier with new one
       Fastlane::FastFile.new.parse("lane :test do
           update_changelog(changelog_path: '#{changelog_mock_path}',
                            section_identifier: '#{existing_section_identifier}',

--- a/spec/update_changelog_action_with_placeholder_action_spec.rb
+++ b/spec/update_changelog_action_with_placeholder_action_spec.rb
@@ -1,0 +1,112 @@
+describe Fastlane::Actions::UpdateChangelogAction do
+  describe 'Update CHANGELOG.md with placeholder line action' do
+    let (:changelog_mock_path) { './../spec/fixtures/CHANGELOG_MOCK_PLACEHOLDER_SUPPORT.md' }
+    let (:changelog_mock_path_hook) { './spec/fixtures/CHANGELOG_MOCK_PLACEHOLDER_SUPPORT.md' } # Path to mock CHANGELOG.md with format for placeholders support in [Unreleased] section (https://github.com/dblock/danger-changelog)
+    let (:updated_section_identifier) { '12.34.56' }
+    let (:existing_section_identifier) { '[0.3.0]' }
+    let (:placeholder_line) { '* Your contribution here.' }
+    let (:unreleased_identifier) { '[Unreleased]' }
+
+    before(:each) do
+      @original_content = File.read(changelog_mock_path_hook)
+    end
+
+    after(:each) do
+      File.open(changelog_mock_path_hook, 'w') { |f| f.write(@original_content) }
+    end
+
+    it 'updates [Unreleased] section identifier' do
+      # Read what's in [Unreleased] section
+      read_result = Fastlane::FastFile.new.parse("lane :test do
+          read_changelog(changelog_path: '#{changelog_mock_path}')
+        end").runner.execute(:test)
+
+      # Update [Unreleased] section identifier with new one
+      Fastlane::FastFile.new.parse("lane :test do
+        update_changelog(changelog_path: '#{changelog_mock_path}',
+                          updated_section_identifier: '#{updated_section_identifier}')
+      end").runner.execute(:test)
+
+      # Read updated section
+      post_update_read_result = Fastlane::FastFile.new.parse("lane :test do
+          read_changelog(changelog_path: '#{changelog_mock_path}',
+                         section_identifier: '[#{updated_section_identifier}]')
+        end").runner.execute(:test)
+
+      expect(read_result).to eq(post_update_read_result)
+    end
+
+    it 'updates specific section identifier' do
+      # Read what's in specified section
+      read_result = Fastlane::FastFile.new.parse("lane :test do
+          read_changelog(changelog_path: '#{changelog_mock_path}',
+                         section_identifier: '#{existing_section_identifier}')
+        end").runner.execute(:test)
+
+      # Update given section identifier with new one
+      Fastlane::FastFile.new.parse("lane :test do
+          update_changelog(changelog_path: '#{changelog_mock_path}',
+                           section_identifier: '#{existing_section_identifier}',
+                           updated_section_identifier: '#{updated_section_identifier}')
+        end").runner.execute(:test)
+
+      # Read updated section
+      post_update_read_result = Fastlane::FastFile.new.parse("lane :test do
+          read_changelog(changelog_path: '#{changelog_mock_path}',
+                         section_identifier: '[#{updated_section_identifier}]')
+        end").runner.execute(:test)
+
+      expect(read_result).to eq(post_update_read_result)
+    end
+
+    it 'updates [Unreleased] section identifier while excluding placeholder line' do
+      # Read what's in [Unreleased] section
+      read_result = Fastlane::FastFile.new.parse("lane :test do
+          read_changelog(changelog_path: '#{changelog_mock_path}')
+        end").runner.execute(:test)
+
+      # Update given section identifier with new one while excluding the placeholder line
+      Fastlane::FastFile.new.parse("lane :test do
+          update_changelog(changelog_path: '#{changelog_mock_path}',
+                           updated_section_identifier: '#{updated_section_identifier}',
+                           excluded_placeholder_line: '#{placeholder_line}')
+        end").runner.execute(:test)
+
+      # Read updated section
+      post_update_read_result = Fastlane::FastFile.new.parse("lane :test do
+          read_changelog(changelog_path: '#{changelog_mock_path}',
+                         section_identifier: '[#{updated_section_identifier}]')
+        end").runner.execute(:test)
+
+      # Verify placeholder line is excluded
+      expect(read_result).not_to eq(post_update_read_result)
+      expect(post_update_read_result =~ /^#{placeholder_line}/).to be_falsey
+    end
+
+    it 'updates specific section identifier while excluding placeholder line' do
+      # Read what's in specified section
+      read_result = Fastlane::FastFile.new.parse("lane :test do
+          read_changelog(changelog_path: '#{changelog_mock_path}',
+                         section_identifier: '#{existing_section_identifier}')
+        end").runner.execute(:test)
+
+      # Update given section identifier with new one while excluding the placeholder line
+      Fastlane::FastFile.new.parse("lane :test do
+          update_changelog(changelog_path: '#{changelog_mock_path}',
+                           section_identifier: '#{existing_section_identifier}',
+                           updated_section_identifier: '#{updated_section_identifier}',
+                           excluded_placeholder_line: '#{placeholder_line}')
+        end").runner.execute(:test)
+
+      # Read updated section
+      post_update_read_result = Fastlane::FastFile.new.parse("lane :test do
+          read_changelog(changelog_path: '#{changelog_mock_path}',
+                         section_identifier: '[#{updated_section_identifier}]')
+        end").runner.execute(:test)
+
+      # Verify placeholder line is not excluded (section [0.0.3] doesn't have a placeholder line to remove)
+      expect(read_result).to eq(post_update_read_result)
+      expect(post_update_read_result =~ /^#{placeholder_line}/).to be_falsey
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a functionality requested in https://github.com/pajapro/fastlane-plugin-changelog/issues/22. 