### PR TITLE
Remove prompt for creating CHANGEPLAN.md in project root

### DIFF
--- a/lib/fastlane/plugin/changelog.rb
+++ b/lib/fastlane/plugin/changelog.rb
@@ -2,7 +2,6 @@ require 'fastlane/plugin/changelog/version'
 
 module Fastlane
   module Changelog
-
     # Return all .rb files inside the "actions" and "helper" directory
     def self.all_classes
       Dir[File.expand_path('**/{actions,helper}/*.rb', File.dirname(__FILE__))]

--- a/lib/fastlane/plugin/changelog.rb
+++ b/lib/fastlane/plugin/changelog.rb
@@ -2,69 +2,12 @@ require 'fastlane/plugin/changelog/version'
 
 module Fastlane
   module Changelog
-    CHANGELOG_PATH = './CHANGELOG.md'
-    DEFAULT_CHANGELOG = '# Change Log
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](http://keepachangelog.com/)
-and this project adheres to [Semantic Versioning](http://semver.org/).
-
-## [Unreleased]
-### Added
-- Your awesome new feature'
 
     # Return all .rb files inside the "actions" and "helper" directory
     def self.all_classes
       Dir[File.expand_path('**/{actions,helper}/*.rb', File.dirname(__FILE__))]
     end
 
-    # Offer user to setup CHANGELOG.md file in project folder (unless it already exists)
-    def self.setup_changelog
-      unless has_changelog?
-        if FastlaneCore::UI.confirm('Your project folder does not have CHANGELOG.md - do you want to create one now?')
-          create_changelog
-
-          FastlaneCore::UI.message('Changelog plugin can automaticaly create a link for comparison between two tags (see https://github.com/pajapro/fastlane-plugin-changelog#--stamp_changelog)')
-          if FastlaneCore::UI.confirm('Do you want to create links for comparing tags?')
-            repo_url = FastlaneCore::UI.input('Enter your GitHub or Bitbucket repository URL (e.g.: https://github.com/owner/project or https://bitbucket.org/owner/project):')
-            create_comparison_link(repo_url)
-          else
-            write_to_changelog(DEFAULT_CHANGELOG)
-          end
-        end
-      end
-    end
-
-    # Does CHANGELOG.md exists in project folder?
-    def self.has_changelog?
-      File.exist?(CHANGELOG_PATH)
-    end
-
-    # Create CHANGELOG.md file
-    def self.create_changelog
-      FileUtils.touch 'CHANGELOG.md'
-    end
-
-    # Create a link for tag comparison
-    def self.create_comparison_link(repo_url)
-      if repo_url.start_with?('https://github.com')
-        output = DEFAULT_CHANGELOG + "\n\n[Unreleased]: #{repo_url}/compare/master...HEAD"
-        write_to_changelog(output)
-      elsif repo_url.start_with?('https://bitbucket.org')
-        output = DEFAULT_CHANGELOG + "\n\n[Unreleased]: #{repo_url}/compare/master..HEAD"
-        write_to_changelog(output)
-      else
-        FastlaneCore::UI.error('Unknown repository host')
-        FastlaneCore::UI.message('Creating CHANGELOG.md without links for comparing tags')
-        write_to_changelog(DEFAULT_CHANGELOG)
-      end
-    end
-
-    # Write given content to CHANGELOG.md
-    def self.write_to_changelog(changelog)
-      File.open(CHANGELOG_PATH, 'w') { |f| f.write(changelog) }
-      FastlaneCore::UI.success('Successfuly created CHANGELOG.md')
-    end
   end
 end
 
@@ -73,6 +16,3 @@ end
 Fastlane::Changelog.all_classes.each do |current|
   require current
 end
-
-# By default we want to ensure CHANGELOG.md is present
-Fastlane::Changelog.setup_changelog

--- a/lib/fastlane/plugin/changelog/actions/emojify_changelog.rb
+++ b/lib/fastlane/plugin/changelog/actions/emojify_changelog.rb
@@ -11,7 +11,7 @@ module Fastlane
         UI.message "Emojifying the output of read_changelog action"
 
         read_changelog_output = lane_context[SharedValues::READ_CHANGELOG_SECTION_CONTENT]
-        changelog_path = lane_context[SharedValues::READ_CHANGELOG_CHANGELOG_PATH]
+        changelog_path = lane_context[SharedValues::FL_CHANGELOG_PATH]
 
         line_separator = Helper::ChangelogHelper.get_line_separator(changelog_path)
         emojified_content = ""

--- a/lib/fastlane/plugin/changelog/actions/emojify_changelog.rb
+++ b/lib/fastlane/plugin/changelog/actions/emojify_changelog.rb
@@ -11,7 +11,7 @@ module Fastlane
         UI.message "Emojifying the output of read_changelog action"
 
         read_changelog_output = lane_context[SharedValues::READ_CHANGELOG_SECTION_CONTENT]
-        changelog_path = lane_context[SharedValues::FL_CHANGELOG_PATH]
+        changelog_path = lane_context[SharedValues::READ_CHANGELOG_CHANGELOG_PATH]
 
         line_separator = Helper::ChangelogHelper.get_line_separator(changelog_path)
         emojified_content = ""

--- a/lib/fastlane/plugin/changelog/actions/read_changelog.rb
+++ b/lib/fastlane/plugin/changelog/actions/read_changelog.rb
@@ -8,7 +8,7 @@ module Fastlane
     class ReadChangelogAction < Action
       def self.run(params)
         changelog_path = params[:changelog_path] unless params[:changelog_path].to_s.empty?
-        UI.error("CHANGELOG.md at path '#{changelog_path}' does not exist") unless File.exist?(changelog_path)
+        Helper::ChangelogHelper.ensure_changelog_exists(changelog_path)
 
         section_identifier = params[:section_identifier] unless params[:section_identifier].to_s.empty?
         escaped_section_identifier = Regexp.escape(section_identifier[/\[(.*?)\]/, 1])

--- a/lib/fastlane/plugin/changelog/actions/read_changelog.rb
+++ b/lib/fastlane/plugin/changelog/actions/read_changelog.rb
@@ -77,7 +77,7 @@ module Fastlane
       def self.available_options
         [
           FastlaneCore::ConfigItem.new(key: :changelog_path,
-                                       env_name: "FL_READ_CHANGELOG_PATH_TO_CHANGELOG",
+                                       env_name: "FL_CHANGELOG_PATH",
                                        description: "The path to your project CHANGELOG.md",
                                        is_string: true,
                                        default_value: "./CHANGELOG.md",

--- a/lib/fastlane/plugin/changelog/actions/read_changelog.rb
+++ b/lib/fastlane/plugin/changelog/actions/read_changelog.rb
@@ -8,7 +8,7 @@ module Fastlane
     class ReadChangelogAction < Action
       def self.run(params)
         changelog_path = params[:changelog_path] unless params[:changelog_path].to_s.empty?
-        Helper::ChangelogHelper.ensure_changelog_exists(changelog_path)
+        changelog_path = Helper::ChangelogHelper.ensure_changelog_exists(changelog_path)
 
         section_identifier = params[:section_identifier] unless params[:section_identifier].to_s.empty?
         escaped_section_identifier = Regexp.escape(section_identifier[/\[(.*?)\]/, 1])

--- a/lib/fastlane/plugin/changelog/actions/stamp_changelog.rb
+++ b/lib/fastlane/plugin/changelog/actions/stamp_changelog.rb
@@ -108,7 +108,7 @@ module Fastlane
       def self.available_options
         [
           FastlaneCore::ConfigItem.new(key: :changelog_path,
-                                       env_name: "FL_STAMP_CHANGELOG_PATH_TO_CHANGELOG",
+                                       env_name: "FL_CHANGELOG_PATH",
                                        description: "The path to your project CHANGELOG.md",
                                        is_string: true,
                                        default_value: "./CHANGELOG.md",

--- a/lib/fastlane/plugin/changelog/actions/stamp_changelog.rb
+++ b/lib/fastlane/plugin/changelog/actions/stamp_changelog.rb
@@ -6,7 +6,7 @@ module Fastlane
       def self.run(params)
         # 1. Ensure CHANGELOG.md exists
         changelog_path = params[:changelog_path] unless params[:changelog_path].to_s.empty?
-        Helper::ChangelogHelper.ensure_changelog_exists(changelog_path)
+        changelog_path = Helper::ChangelogHelper.ensure_changelog_exists(changelog_path)
 
         # 2. Ensure there are changes in [Unreleased] section
         unreleased_section_content = Actions::ReadChangelogAction.run(changelog_path: changelog_path, section_identifier: UNRELEASED_IDENTIFIER, excluded_markdown_elements: ["###"])

--- a/lib/fastlane/plugin/changelog/actions/stamp_changelog.rb
+++ b/lib/fastlane/plugin/changelog/actions/stamp_changelog.rb
@@ -6,7 +6,7 @@ module Fastlane
       def self.run(params)
         # 1. Ensure CHANGELOG.md exists
         changelog_path = params[:changelog_path] unless params[:changelog_path].to_s.empty?
-        UI.error("CHANGELOG.md at path '#{changelog_path}' does not exist") unless File.exist?(changelog_path)
+        Helper::ChangelogHelper.ensure_changelog_exists(changelog_path)
 
         # 2. Ensure there are changes in [Unreleased] section
         unreleased_section_content = Actions::ReadChangelogAction.run(changelog_path: changelog_path, section_identifier: UNRELEASED_IDENTIFIER, excluded_markdown_elements: ["###"])

--- a/lib/fastlane/plugin/changelog/actions/update_changelog.rb
+++ b/lib/fastlane/plugin/changelog/actions/update_changelog.rb
@@ -3,7 +3,7 @@ module Fastlane
     class UpdateChangelogAction < Action
       def self.run(params)
         changelog_path = params[:changelog_path] unless params[:changelog_path].to_s.empty?
-        Helper::ChangelogHelper.ensure_changelog_exists(changelog_path)
+        changelog_path = Helper::ChangelogHelper.ensure_changelog_exists(changelog_path)
 
         section_identifier = params[:section_identifier] unless params[:section_identifier].to_s.empty?
         escaped_section_identifier = section_identifier[/\[(.*?)\]/, 1]

--- a/lib/fastlane/plugin/changelog/actions/update_changelog.rb
+++ b/lib/fastlane/plugin/changelog/actions/update_changelog.rb
@@ -3,7 +3,7 @@ module Fastlane
     class UpdateChangelogAction < Action
       def self.run(params)
         changelog_path = params[:changelog_path] unless params[:changelog_path].to_s.empty?
-        UI.error("CHANGELOG.md at path '#{changelog_path}' does not exist") unless File.exist?(changelog_path)
+        Helper::ChangelogHelper.ensure_changelog_exists(changelog_path)
 
         section_identifier = params[:section_identifier] unless params[:section_identifier].to_s.empty?
         escaped_section_identifier = section_identifier[/\[(.*?)\]/, 1]

--- a/lib/fastlane/plugin/changelog/actions/update_changelog.rb
+++ b/lib/fastlane/plugin/changelog/actions/update_changelog.rb
@@ -95,7 +95,7 @@ module Fastlane
       def self.available_options
         [
           FastlaneCore::ConfigItem.new(key: :changelog_path,
-                                       env_name: "FL_UPDATE_CHANGELOG_PATH_TO_CHANGELOG",
+                                       env_name: "FL_CHANGELOG_PATH",
                                        description: "The path to your project CHANGELOG.md",
                                        is_string: true,
                                        default_value: "./CHANGELOG.md",

--- a/lib/fastlane/plugin/changelog/helper/changelog_helper.rb
+++ b/lib/fastlane/plugin/changelog/helper/changelog_helper.rb
@@ -12,6 +12,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Your awesome new feature'
 
     class ChangelogHelper
+
+      # Ensures CHANGELOG.md exists at given path. If not, offers to create a default one.
+      def self.ensure_changelog_exists(path)
+        if File.exist?(path)
+          FastlaneCore::UI.success "Found CHANGELOG.md at #{path}"
+        else 
+          generate_changelog  
+        end
+      end
+
       # Generates CHANGELOG.md in project root
       def self.generate_changelog
         if FastlaneCore::UI.confirm('Your project folder does not have CHANGELOG.md - do you want to create one now?')

--- a/lib/fastlane/plugin/changelog/helper/changelog_helper.rb
+++ b/lib/fastlane/plugin/changelog/helper/changelog_helper.rb
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Your awesome new feature'
 
+    # TODO: ❗️ Add unit tests for methods in this class
     class ChangelogHelper
 
       # Ensures CHANGELOG.md exists at given path. If not, offers to create a default one. 

--- a/lib/fastlane/plugin/changelog/helper/changelog_helper.rb
+++ b/lib/fastlane/plugin/changelog/helper/changelog_helper.rb
@@ -13,12 +13,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
     class ChangelogHelper
 
-      # Ensures CHANGELOG.md exists at given path. If not, offers to create a default one.
+      # Ensures CHANGELOG.md exists at given path. If not, offers to create a default one. 
+      # Returns path to CHANGELOG.md to be used
       def self.ensure_changelog_exists(path)
         if File.exist?(path)
           FastlaneCore::UI.success "Found CHANGELOG.md at #{path}"
-        else 
-          generate_changelog  
+          path
+        else
+          FastlaneCore::UI.message("Cannot find CHANGELOG.md at #{path}")
+          generate_changelog
+          CHANGELOG_PATH
         end
       end
 

--- a/lib/fastlane/plugin/changelog/helper/changelog_helper.rb
+++ b/lib/fastlane/plugin/changelog/helper/changelog_helper.rb
@@ -1,13 +1,59 @@
 module Fastlane
   module Helper
+    CHANGELOG_PATH = './CHANGELOG.md'
+    DEFAULT_CHANGELOG = '# Change Log
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [Unreleased]
+### Added
+- Your awesome new feature'
+
     class ChangelogHelper
-      # class methods that you define here become available in your action
-      # as `Helper::ChangelogHelper.your_method`
-      #
-      def self.show_message
-        UI.message("Hello from the changelog plugin helper!")
+      # Generates CHANGELOG.md in project root
+      def self.generate_changelog
+        if FastlaneCore::UI.confirm('Your project folder does not have CHANGELOG.md - do you want to create one now?')
+            FileUtils.touch 'CHANGELOG.md'
+            generate_comparison_link
+        else 
+            FastlaneCore::UI.error("Cannot continue without CHANGELOG.md file")
+        end
       end
 
+      # Generates link for tag comparison
+      def self.generate_comparison_link     
+        FastlaneCore::UI.message('Changelog plugin can automaticaly create a link for comparison between two tags (see https://github.com/pajapro/fastlane-plugin-changelog#--stamp_changelog)')
+        if FastlaneCore::UI.confirm('Do you want to create links for comparing tags?')
+          repo_url = FastlaneCore::UI.input('Enter your GitHub or Bitbucket repository URL (e.g.: https://github.com/owner/project or https://bitbucket.org/owner/project):')
+          compose_comparison_link(repo_url)
+        else
+          write_to_changelog(DEFAULT_CHANGELOG)
+        end
+      end
+
+      # Composes link for tag comparison for GitHub or Bitbucket
+      def self.compose_comparison_link(repo_url)
+        if repo_url.start_with?('https://github.com')
+          output = DEFAULT_CHANGELOG + "\n\n[Unreleased]: #{repo_url}/compare/master...HEAD"
+          write_to_changelog(output)
+        elsif repo_url.start_with?('https://bitbucket.org')
+          output = DEFAULT_CHANGELOG + "\n\n[Unreleased]: #{repo_url}/compare/master..HEAD"
+          write_to_changelog(output)
+        else
+          FastlaneCore::UI.error('Unknown repository host')
+          FastlaneCore::UI.message('Creating CHANGELOG.md without links for comparing tags')
+          write_to_changelog(DEFAULT_CHANGELOG)
+        end
+      end
+
+      # Writes given content to CHANGELOG.md in project root
+      def self.write_to_changelog(changelog)
+        File.open(CHANGELOG_PATH, 'w') { |f| f.write(changelog) }
+        FastlaneCore::UI.success('Successfuly created CHANGELOG.md')
+      end
+      
       def self.get_line_separator(file_path)
         f = File.open(file_path)
         enum = f.each_char

--- a/lib/fastlane/plugin/changelog/helper/changelog_helper.rb
+++ b/lib/fastlane/plugin/changelog/helper/changelog_helper.rb
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
       # Generates CHANGELOG.md in project root
       def self.generate_changelog
-        if FastlaneCore::UI.confirm('Your project folder does not have CHANGELOG.md - do you want to create one now?')
+        if FastlaneCore::UI.confirm('Do you want to generate default CHANGELOG.md in the project root?')
             FileUtils.touch 'CHANGELOG.md'
             generate_comparison_link
         else 


### PR DESCRIPTION
Based on reported issues (https://github.com/pajapro/fastlane-plugin-changelog/issues/28 and https://github.com/pajapro/fastlane-plugin-changelog/issues/23) this PR removes the prompt for creating `CHANGELOG.md` in project root every time an action is executed with _different_ `changelog_path` param.

Users can now for example:

## Read CHANGELOG.md placed outside of current project:
```
bundle exec fastlane run read_changelog changelog_path:'/Users/pavelprochazka/Desktop/CHANGELOG.md'
[✔] 🚀
+---------------------------+---------+----------------------------------------------------+
|                                       Used plugins                                       |
+---------------------------+---------+----------------------------------------------------+
| Plugin                    | Version | Action                                             |
+---------------------------+---------+----------------------------------------------------+
| fastlane-plugin-changelog | 0.9.0   | read_changelog update_changelog emojify_changelog  |
|                           |         | stamp_changelog                                    |
+---------------------------+---------+----------------------------------------------------+

[16:12:54]: ----------------------------
[16:12:54]: --- Step: read_changelog ---
[16:12:54]: ----------------------------
[16:12:54]: Found CHANGELOG.md at /Users/pavelprochazka/Desktop/CHANGELOG.md
[16:12:54]: Starting to read [Unreleased] section from '/Users/pavelprochazka/Desktop/CHANGELOG.md'
[16:12:54]: Finished reading [Unreleased] section from '/Users/pavelprochazka/Desktop/CHANGELOG.md'
[16:12:54]: Result: Added
- Your awesome new feature

[Unreleased]: https://github.com/owner/project/compare/master...HEAD
```

## Stamp CHANGELOG.md placed outside of current project:
```
bundle exec fastlane run stamp_changelog changelog_path:'/Users/pavelprochazka/Desktop/CHANGELOG.md' section_identifier:'Build XYZ'
[✔] 🚀
+---------------------------+---------+----------------------------------------------------+
|                                       Used plugins                                       |
+---------------------------+---------+----------------------------------------------------+
| Plugin                    | Version | Action                                             |
+---------------------------+---------+----------------------------------------------------+
| fastlane-plugin-changelog | 0.9.0   | read_changelog update_changelog emojify_changelog  |
|                           |         | stamp_changelog                                    |
+---------------------------+---------+----------------------------------------------------+

[16:05:23]: -----------------------------
[16:05:23]: --- Step: stamp_changelog ---
[16:05:23]: -----------------------------
[16:05:23]: Found CHANGELOG.md at /Users/pavelprochazka/Desktop/CHANGELOG.md
[16:05:23]: Found CHANGELOG.md at /Users/pavelprochazka/Desktop/CHANGELOG.md
[16:05:23]: Starting to read [Unreleased] section from '/Users/pavelprochazka/Desktop/CHANGELOG.md'
[16:05:23]: Finished reading [Unreleased] section from '/Users/pavelprochazka/Desktop/CHANGELOG.md'
[16:05:23]: Found CHANGELOG.md at /Users/pavelprochazka/Desktop/CHANGELOG.md
[16:05:23]: Starting to update [Unreleased] section of '/Users/pavelprochazka/Desktop/CHANGELOG.md'
[16:05:23]: Old section identifier: ## [Unreleased]
[16:05:23]: New section identifier: ## [Build XYZ] - 2018-11-11
[16:05:23]: Successfuly updated /Users/pavelprochazka/Desktop/CHANGELOG.md
[16:05:23]: Created [Unreleased] placeholder section
[16:05:23]: Successfuly stamped Build XYZ in /Users/pavelprochazka/Desktop/CHANGELOG.md
```