### PR TITLE
Git tags comparison link fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ Gemfile.lock
 /rdoc/
 fastlane/README.md
 fastlane/report.xml
+/.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.11.0] - 2018-11-16
+### Fixed:
+- Bug when creating git tags comparison link ([Issue #32](https://github.com/pajapro/fastlane-plugin-changelog/issues/32)) 
+
 ## [0.10.0] - 2018-11-11
 ### Fixed:
 - Remove prompt to create `CHANGELOG.md` in project root, while using custom `changelog_path` param ([Issue #28](https://github.com/pajapro/fastlane-plugin-changelog/issues/28) and [Issue #23](https://github.com/pajapro/fastlane-plugin-changelog/issues/23))
@@ -78,3 +82,4 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 [0.8.0]: https://github.com/pajapro/fastlane-plugin-changelog/compare/v0.7.0...v0.8.0
 [0.9.0]: https://github.com/pajapro/fastlane-plugin-changelog/compare/v0.8.0...v0.9.0
 [0.10.0]: https://github.com/pajapro/fastlane-plugin-changelog/compare/v0.9.0...v0.10.0
+[0.11.0]: https://github.com/pajapro/fastlane-plugin-changelog/compare/v0.10.0...v0.11.0

--- a/lib/fastlane/plugin/changelog.rb
+++ b/lib/fastlane/plugin/changelog.rb
@@ -6,7 +6,6 @@ module Fastlane
     def self.all_classes
       Dir[File.expand_path('**/{actions,helper}/*.rb', File.dirname(__FILE__))]
     end
-
   end
 end
 

--- a/lib/fastlane/plugin/changelog/actions/stamp_changelog.rb
+++ b/lib/fastlane/plugin/changelog/actions/stamp_changelog.rb
@@ -64,7 +64,6 @@ module Fastlane
         # 3. Create link to git tags diff
         if !git_tag.nil? && !git_tag.empty?
           last_line = file_content.lines.last
-          previous_section_name = last_line[/\[(.*?)\]/, 1]
           previous_tag = ""
           previous_previous_tag = ""
 

--- a/lib/fastlane/plugin/changelog/actions/stamp_changelog.rb
+++ b/lib/fastlane/plugin/changelog/actions/stamp_changelog.rb
@@ -76,9 +76,16 @@ module Fastlane
             previous_previous_tag = /(?<=\.{2})(.*)?/.match(last_line)
           end
 
-          last_line.sub!(previous_tag.to_s, git_tag) # Replace previous tag with new
-          last_line.sub!(previous_previous_tag.to_s, previous_tag.to_s) # Replace previous-previous tag with previous
-          last_line.sub!(previous_section_name.to_s, section_identifier) # Replace section identifier
+          # Replace section identifier
+          cleared_git_tag = git_tag.delete('[a-z]')
+          cleared_previous_git_tag = previous_tag.to_s.delete('[a-z]')
+          last_line.sub!("[#{cleared_previous_git_tag}]", "[#{cleared_git_tag}]")
+
+          # Replace previous-previous tag with previous
+          last_line.sub!(previous_previous_tag.to_s, previous_tag.to_s)
+
+          # Replace previous tag with new
+          last_line.sub!("..#{previous_tag.to_s}", "..#{git_tag.to_s}")
 
           UI.message("Created a link for comparison between #{previous_tag} and #{git_tag} tag")
 

--- a/lib/fastlane/plugin/changelog/actions/stamp_changelog.rb
+++ b/lib/fastlane/plugin/changelog/actions/stamp_changelog.rb
@@ -43,10 +43,10 @@ module Fastlane
               # Insert placeholder line (if provided)
               if !placeholder_line.nil? && !placeholder_line.empty?
                 line = "#{unreleased_section}\n#{placeholder_line}\n\n#{line}"
-              else 
+              else
                 line = "#{unreleased_section}\n\n#{line}"
-              end  
-              
+              end
+
               inserted_unreleased = true
 
               UI.message("Created [Unreleased] placeholder section")
@@ -85,7 +85,7 @@ module Fastlane
           last_line.sub!(previous_previous_tag.to_s, previous_tag.to_s)
 
           # Replace previous tag with new
-          last_line.sub!("..#{previous_tag.to_s}", "..#{git_tag.to_s}")
+          last_line.sub!("..#{previous_tag}", "..#{git_tag}")
 
           UI.message("Created a link for comparison between #{previous_tag} and #{git_tag} tag")
 

--- a/lib/fastlane/plugin/changelog/actions/stamp_changelog.rb
+++ b/lib/fastlane/plugin/changelog/actions/stamp_changelog.rb
@@ -61,7 +61,7 @@ module Fastlane
           end
         end
 
-        # 3. Create link to Github tags diff
+        # 3. Create link to git tags diff
         if !git_tag.nil? && !git_tag.empty?
           last_line = file_content.lines.last
           previous_section_name = last_line[/\[(.*?)\]/, 1]

--- a/lib/fastlane/plugin/changelog/actions/update_changelog.rb
+++ b/lib/fastlane/plugin/changelog/actions/update_changelog.rb
@@ -20,7 +20,6 @@ module Fastlane
         File.open(changelog_path, "r") do |file|
           line_separator = Helper::ChangelogHelper.get_line_separator(changelog_path)
           file.each_line do |line|
-
             # 3. Ignore placeholder line (if provided) within the updated section
             if found_identifying_section && !excluded_placeholder_line.nil?
               if isSectionLine(line)
@@ -28,7 +27,7 @@ module Fastlane
               else
                 if line =~ /^#{excluded_placeholder_line}/
                   next # Ignore placeholder line, don't output it
-                else 
+                else
                   file_content.concat(line) # Output unmodified line
                   next
                 end
@@ -77,7 +76,7 @@ module Fastlane
       end
 
       def self.isSectionLine(line)
-         line =~ /\#{2}\s?\[.*\]/
+        line =~ /\#{2}\s?\[.*\]/
       end
 
       #####################################################

--- a/lib/fastlane/plugin/changelog/actions/update_changelog.rb
+++ b/lib/fastlane/plugin/changelog/actions/update_changelog.rb
@@ -22,7 +22,7 @@ module Fastlane
           file.each_line do |line|
             # 3. Ignore placeholder line (if provided) within the updated section
             if found_identifying_section && !excluded_placeholder_line.nil?
-              if isSectionLine(line)
+              if is_section_line(line)
                 found_identifying_section = false # Reached the end of section, hence stop reading
               else
                 if line =~ /^#{excluded_placeholder_line}/
@@ -75,7 +75,7 @@ module Fastlane
         UI.success("Successfuly updated #{changelog_path}")
       end
 
-      def self.isSectionLine(line)
+      def self.is_section_line(line)
         line =~ /\#{2}\s?\[.*\]/
       end
 

--- a/lib/fastlane/plugin/changelog/helper/changelog_helper.rb
+++ b/lib/fastlane/plugin/changelog/helper/changelog_helper.rb
@@ -13,8 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
     # TODO: ❗️ Add unit tests for methods in this class
     class ChangelogHelper
-
-      # Ensures CHANGELOG.md exists at given path. If not, offers to create a default one. 
+      # Ensures CHANGELOG.md exists at given path. If not, offers to create a default one.
       # Returns path to CHANGELOG.md to be used
       def self.ensure_changelog_exists(path)
         if File.exist?(path)
@@ -30,15 +29,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
       # Generates CHANGELOG.md in project root
       def self.generate_changelog
         if FastlaneCore::UI.confirm('Do you want to generate default CHANGELOG.md in the project root?')
-            FileUtils.touch 'CHANGELOG.md'
-            generate_comparison_link
-        else 
-            FastlaneCore::UI.error("Cannot continue without CHANGELOG.md file")
+          FileUtils.touch 'CHANGELOG.md'
+          generate_comparison_link
+        else
+          FastlaneCore::UI.error("Cannot continue without CHANGELOG.md file")
         end
       end
 
       # Generates link for tag comparison
-      def self.generate_comparison_link     
+      def self.generate_comparison_link
         FastlaneCore::UI.message('Changelog plugin can automaticaly create a link for comparison between two tags (see https://github.com/pajapro/fastlane-plugin-changelog#--stamp_changelog)')
         if FastlaneCore::UI.confirm('Do you want to create links for comparing tags?')
           repo_url = FastlaneCore::UI.input('Enter your GitHub or Bitbucket repository URL (e.g.: https://github.com/owner/project or https://bitbucket.org/owner/project):')
@@ -68,7 +67,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
         File.open(CHANGELOG_PATH, 'w') { |f| f.write(changelog) }
         FastlaneCore::UI.success('Successfuly created CHANGELOG.md')
       end
-      
+
       def self.get_line_separator(file_path)
         f = File.open(file_path)
         enum = f.each_char

--- a/lib/fastlane/plugin/changelog/helper/changelog_helper.rb
+++ b/lib/fastlane/plugin/changelog/helper/changelog_helper.rb
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Your awesome new feature'
 
-    # TODO: ❗️ Add unit tests for methods in this class
+    # TODO: Add unit tests for methods in this class
     class ChangelogHelper
       # Ensures CHANGELOG.md exists at given path. If not, offers to create a default one.
       # Returns path to CHANGELOG.md to be used

--- a/lib/fastlane/plugin/changelog/version.rb
+++ b/lib/fastlane/plugin/changelog/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Changelog
-    VERSION = "0.10.0"
+    VERSION = "0.11.0"
   end
 end

--- a/spec/fixtures/CHANGELOG_MOCK_PLACEHOLDER_SUPPORT.md
+++ b/spec/fixtures/CHANGELOG_MOCK_PLACEHOLDER_SUPPORT.md
@@ -107,14 +107,16 @@ notable changes.
 - Good examples and basic guidelines, including proper date formatting.
 - Counter-examples: "What makes unicorns cry?"
 
-[0.0.1]: https://github.com/olivierlacan/keep-a-changelog/compare/...v0.0.1
-[0.0.2]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.1...v0.0.2
-[0.0.3]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.2...v0.0.3
-[0.0.4]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.3...v0.0.4
-[0.0.5]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.4...v0.0.5
-[0.0.6]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.5...v0.0.6
-[0.0.7]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.6...v0.0.7
-[0.0.8]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.7...v0.0.8
-[0.1.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.8...v0.1.0
-[0.2.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.1.0...v0.2.0
-[0.3.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.2.0...v0.3.0
+[0.0.1]: https://github.com/olivierlacan/keep-a-changelog/compare/...0.0.1
+[0.0.2]: https://github.com/olivierlacan/keep-a-changelog/compare/0.0.1...0.0.2
+[0.0.3]: https://github.com/olivierlacan/keep-a-changelog/compare/0.0.2...0.0.3
+[0.0.4]: https://github.com/olivierlacan/keep-a-changelog/compare/0.0.3...0.0.4
+[0.0.5]: https://github.com/olivierlacan/keep-a-changelog/compare/0.0.4...0.0.5
+[0.0.6]: https://github.com/olivierlacan/keep-a-changelog/compare/0.0.5...0.0.6
+[0.0.7]: https://github.com/olivierlacan/keep-a-changelog/compare/0.0.6...0.0.7
+[0.0.8]: https://github.com/olivierlacan/keep-a-changelog/compare/0.0.7...0.0.8
+[0.1.0]: https://github.com/olivierlacan/keep-a-changelog/compare/0.0.8...0.1.0
+[0.2.0]: https://github.com/olivierlacan/keep-a-changelog/compare/0.1.0...0.2.0
+[0.3.0]: https://github.com/olivierlacan/keep-a-changelog/compare/0.2.0...0.3.0
+[3.10.4]: https://github.com/olivierlacan/keep-a-changelog/compare/3.0...3.10.4
+[3.11.0]: https://github.com/olivierlacan/keep-a-changelog/compare/3.10.4...3.11.0

--- a/spec/stamp_changelog_action_spec.rb
+++ b/spec/stamp_changelog_action_spec.rb
@@ -64,7 +64,7 @@ describe Fastlane::Actions::StampChangelogAction do
           end").runner.execute(:test)
     end
 
-    it 'creates tags comparion GitHub link' do
+    it 'creates tags comparion GitHub link with prefix' do
       # Stamp [Unreleased] with given section identifier
       Fastlane::FastFile.new.parse("lane :test do
           stamp_changelog(changelog_path: '#{changelog_mock_path}',
@@ -75,5 +75,6 @@ describe Fastlane::Actions::StampChangelogAction do
       modified_file = File.read(changelog_mock_path_hook)
       expect(modified_file.lines.last).to eq("[12.34.56]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.3.0...v12.34.56\n")
     end
+
   end
 end

--- a/spec/stamp_changelog_action_spec.rb
+++ b/spec/stamp_changelog_action_spec.rb
@@ -75,6 +75,5 @@ describe Fastlane::Actions::StampChangelogAction do
       modified_file = File.read(changelog_mock_path_hook)
       expect(modified_file.lines.last).to eq("[12.34.56]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.3.0...v12.34.56\n")
     end
-
   end
 end

--- a/spec/stamp_changelog_action_spec.rb
+++ b/spec/stamp_changelog_action_spec.rb
@@ -64,7 +64,7 @@ describe Fastlane::Actions::StampChangelogAction do
           end").runner.execute(:test)
     end
 
-    it 'creates tags comparion GitHub link', :focus => true do
+    it 'creates tags comparion GitHub link' do
       # Stamp [Unreleased] with given section identifier
       Fastlane::FastFile.new.parse("lane :test do
           stamp_changelog(changelog_path: '#{changelog_mock_path}',

--- a/spec/stamp_changelog_action_with_placeholder_action_spec.rb
+++ b/spec/stamp_changelog_action_with_placeholder_action_spec.rb
@@ -30,7 +30,6 @@ describe Fastlane::Actions::StampChangelogAction do
     end
 
     context "stamps [Unreleased] section with given identifier" do
-
       it 'creates a new section identifier with provided identifier' do
         # Read what's in [Unreleased]
         read_result = Fastlane::FastFile.new.parse("lane :test do
@@ -65,7 +64,7 @@ describe Fastlane::Actions::StampChangelogAction do
           end").runner.execute(:test)
 
         expect(read_result).to eq("")
-      end    
+      end
 
       it 'excludes placeholder line' do
         # Stamp [Unreleased] with given section identifier and excludes placeholder line
@@ -73,8 +72,8 @@ describe Fastlane::Actions::StampChangelogAction do
             stamp_changelog(changelog_path: '#{changelog_mock_path}',
                             section_identifier: '#{updated_section_identifier}',
                             placeholder_line: '#{placeholder_line}')
-            end").runner.execute(:test)      
-        
+            end").runner.execute(:test)
+
         # Read updated section
         post_stamp_read_result = Fastlane::FastFile.new.parse("lane :test do
             read_changelog(changelog_path: '#{changelog_mock_path}',
@@ -90,8 +89,8 @@ describe Fastlane::Actions::StampChangelogAction do
             stamp_changelog(changelog_path: '#{changelog_mock_path}',
                             section_identifier: '#{updated_section_identifier}',
                             placeholder_line: '#{placeholder_line}')
-            end").runner.execute(:test)      
-        
+            end").runner.execute(:test)
+
         # Read updated section
         read_result = Fastlane::FastFile.new.parse("lane :test do
             read_changelog(changelog_path: '#{changelog_mock_path}')
@@ -107,8 +106,8 @@ describe Fastlane::Actions::StampChangelogAction do
             stamp_changelog(changelog_path: '#{changelog_mock_path}',
                             section_identifier: '#{updated_section_identifier}',
                             placeholder_line: '#{placeholder_line}')
-            end").runner.execute(:test)      
-        
+            end").runner.execute(:test)
+
         # Read updated section
         stamped_section_read_result = Fastlane::FastFile.new.parse("lane :test do
             read_changelog(changelog_path: '#{changelog_mock_path}',

--- a/spec/stamp_changelog_action_with_placeholder_action_spec.rb
+++ b/spec/stamp_changelog_action_with_placeholder_action_spec.rb
@@ -123,6 +123,18 @@ describe Fastlane::Actions::StampChangelogAction do
         expect(stamped_section_read_result =~ /^#{placeholder_line}/).to be_falsey
         expect(unreleased_section_read_result).to eq("* Your contribution here.")
       end
-    end    
+    end
+
+    it 'creates tags comparion GitHub link without prefix' do
+      # Stamp [Unreleased] with given section identifier
+      Fastlane::FastFile.new.parse("lane :test do
+          stamp_changelog(changelog_path: '#{changelog_mock_path}',
+                          section_identifier: '3.11.1',
+                          git_tag: '3.11.1')
+          end").runner.execute(:test)
+
+      modified_file = File.read(changelog_mock_path_hook)
+      expect(modified_file.lines.last).to eq("[3.11.1]: https://github.com/olivierlacan/keep-a-changelog/compare/3.11.0...3.11.1\n")
+    end
   end
 end


### PR DESCRIPTION
Fixing wug when creating git tags comparison link ([Issue #32](https://github.com/pajapro/fastlane-plugin-changelog/issues/32)) 