### PR TITLE
Add support for gitlab and [Unreleased] tags in git diff links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added:
+- Support for gitlab projects
+- Support for diffs with `[Unreleased]` tags (and `HEAD` reference)
 
 ## [0.12.0] - 2018-11-16
 ### Fixed:
@@ -83,3 +86,4 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 [0.9.0]: https://github.com/pajapro/fastlane-plugin-changelog/compare/v0.8.0...v0.9.0
 [0.10.0]: https://github.com/pajapro/fastlane-plugin-changelog/compare/v0.9.0...v0.10.0
 [0.12.0]: https://github.com/pajapro/fastlane-plugin-changelog/compare/v0.10.0...v0.12.0
+[Unreleased]: https://github.com/pajapro/fastlane-plugin-changelog/compare/v0.12.0...HEAD

--- a/lib/fastlane/plugin/changelog/actions/stamp_changelog.rb
+++ b/lib/fastlane/plugin/changelog/actions/stamp_changelog.rb
@@ -25,12 +25,13 @@ module Fastlane
       def self.stamp(changelog_path, section_identifier, stamp_date, git_tag, placeholder_line)
         # 1. Update [Unreleased] section with given identifier
         Actions::UpdateChangelogAction.run(changelog_path: changelog_path,
-                                          section_identifier: UNRELEASED_IDENTIFIER,
-                                          updated_section_identifier: section_identifier,
-                                          append_date: stamp_date,
-                                          excluded_placeholder_line: placeholder_line)
+                                           section_identifier: UNRELEASED_IDENTIFIER,
+                                           updated_section_identifier: section_identifier,
+                                           append_date: stamp_date,
+                                           excluded_placeholder_line: placeholder_line)
 
         file_content = ""
+        last_line = ""
 
         # 2. Create new [Unreleased] section (placeholder)
         inserted_unreleased = false
@@ -57,37 +58,76 @@ module Fastlane
             end
 
             # Output read line
-            file_content.concat(line)
+            file_content.concat(last_line)
+            last_line = line
           end
         end
 
         # 3. Create link to git tags diff
         if !git_tag.nil? && !git_tag.empty?
-          last_line = file_content.lines.last
+          git = ''
           previous_tag = ""
           previous_previous_tag = ""
 
-          if last_line.include? 'https://github.com' # GitHub uses compare/olderTag...newerTag structure
-            previous_previous_tag = %r{(?<=compare\/)(.*)?(?=\.{3})}.match(last_line)
-            previous_tag = /(?<=\.{3})(.*)?/.match(last_line)
+          if last_line.include? 'https://github.com' or last_line.include? 'http://gitlab.' # GitHub and Gitlab use compare/olderTag...newerTag structure
+            git = 1
+            previous_previous_tag = %r{(?<=compare\/)(.*)?(?=\.{3})}.match(last_line).to_s
+            previous_tag = %r{(?<=\.{3})(.*)?}.match(last_line)
           elsif last_line.include? 'https://bitbucket.org' # Bitbucket uses compare/newerTag..olderTag structure
+            git = 2
+            previous_previous_tag = %r{(?<=\.{2})(.*)?}.match(last_line).to_s
             previous_tag = %r{(?<=compare\/)(.*)?(?=\.{2})}.match(last_line)
-            previous_previous_tag = /(?<=\.{2})(.*)?/.match(last_line)
           end
 
-          # Replace section identifier
-          cleared_git_tag = git_tag.delete('[a-z]')
-          cleared_previous_git_tag = previous_tag.to_s.delete('[a-z]')
-          last_line.sub!("[#{cleared_previous_git_tag}]", "[#{cleared_git_tag}]")
+          if last_line.include? UNRELEASED_IDENTIFIER
+            if git == 1
+              last_line.sub!("...HEAD", "...#{git_tag}")
+              last_line.sub!(UNRELEASED_IDENTIFIER, "[#{section_identifier}]")
 
-          # Replace previous-previous tag with previous
-          last_line.sub!(previous_previous_tag.to_s, previous_tag.to_s)
+              file_content.concat(last_line)
 
-          # Replace previous tag with new
-          last_line.sub!("..#{previous_tag}", "..#{git_tag}")
 
-          UI.message("Created a link for comparison between #{previous_tag} and #{git_tag} tag")
+              # Using the modified line to create a new [Unreleased] line
+              last_line.sub!("...#{git_tag}", "...HEAD")
+              last_line.sub!("[#{section_identifier}]", UNRELEASED_IDENTIFIER)
+              last_line.sub!("#{previous_previous_tag}...", "#{git_tag}...")
 
+              file_content.concat(last_line)
+
+            elsif git == 2
+              last_line.sub!("HEAD...", "#{git_tag}...")
+              last_line.sub!(UNRELEASED_IDENTIFIER, "[#{section_identifier}]")
+
+              file_content.concat(last_line)
+
+              last_line.sub!("#{git_tag}...", "HEAD...")
+              last_line.sub!("[#{section_identifier}]", UNRELEASED_IDENTIFIER)
+              last_line.sub!("...#{previous_previous_tag}", "...#{git_tag}")
+
+              file_content.concat(last_line)
+            end
+          else
+            file_content.concat(last_line)
+
+            # Replace section identifier
+            cleared_git_tag = git_tag.delete('[a-z]')
+            cleared_previous_git_tag = previous_tag.to_s.delete('[a-z]')
+            last_line.sub!("[#{cleared_previous_git_tag}]", "[#{cleared_git_tag}]")
+
+            # Replace previous-previous tag with previous
+            last_line.sub!(previous_previous_tag.to_s, previous_tag.to_s)
+
+            # Replace previous tag with new
+            last_line.sub!("..#{previous_tag}", "..#{git_tag}")
+
+            UI.message("Created a link for comparison between #{previous_tag} and #{git_tag} tag")
+
+            file_content.concat(last_line)
+          end
+
+          UI.message("Updated the link for comparison between #{previous_previous_tag} and #{git_tag} tag")
+          UI.message("Created a link for comparison between #{git_tag} and HEAD tag")
+        else
           file_content.concat(last_line)
         end
 
@@ -113,31 +153,31 @@ module Fastlane
 
       def self.available_options
         [
-          FastlaneCore::ConfigItem.new(key: :changelog_path,
-                                       env_name: "FL_CHANGELOG_PATH",
-                                       description: "The path to your project CHANGELOG.md",
-                                       is_string: true,
-                                       default_value: "./CHANGELOG.md",
-                                       optional: true),
-          FastlaneCore::ConfigItem.new(key: :section_identifier,
-                                       env_name: "FL_STAMP_CHANGELOG_SECTION_IDENTIFIER",
-                                       description: "The unique section identifier to stamp the [Unreleased] section with",
-                                       is_string: true),
-          FastlaneCore::ConfigItem.new(key: :stamp_date,
-                                       env_name: "FL_STAMP_CHANGELOG_SECTION_STAMP_DATE",
-                                       description: "Specifies whether the current date should be appended to section identifier",
-                                       default_value: true,
-                                       optional: true),
-          FastlaneCore::ConfigItem.new(key: :git_tag,
-                                       env_name: "FL_STAMP_CHANGELOG_GIT_TAG",
-                                       description: "The git tag associated with this section",
-                                       is_string: true,
-                                       optional: true),
-          FastlaneCore::ConfigItem.new(key: :placeholder_line,
-                                       env_name: "FL_STAMP_CHANGELOG_PLACEHOLDER_LINE",
-                                       description: "The placeholder line to be excluded in stamped section and added to [Unreleased] section",
-                                       is_string: true,
-                                       optional: true)
+            FastlaneCore::ConfigItem.new(key: :changelog_path,
+                                         env_name: "FL_CHANGELOG_PATH",
+                                         description: "The path to your project CHANGELOG.md",
+                                         is_string: true,
+                                         default_value: "./CHANGELOG.md",
+                                         optional: true),
+            FastlaneCore::ConfigItem.new(key: :section_identifier,
+                                         env_name: "FL_STAMP_CHANGELOG_SECTION_IDENTIFIER",
+                                         description: "The unique section identifier to stamp the [Unreleased] section with",
+                                         is_string: true),
+            FastlaneCore::ConfigItem.new(key: :stamp_date,
+                                         env_name: "FL_STAMP_CHANGELOG_SECTION_STAMP_DATE",
+                                         description: "Specifies whether the current date should be appended to section identifier",
+                                         default_value: true,
+                                         optional: true),
+            FastlaneCore::ConfigItem.new(key: :git_tag,
+                                         env_name: "FL_STAMP_CHANGELOG_GIT_TAG",
+                                         description: "The git tag associated with this section",
+                                         is_string: true,
+                                         optional: true),
+            FastlaneCore::ConfigItem.new(key: :placeholder_line,
+                                         env_name: "FL_STAMP_CHANGELOG_PLACEHOLDER_LINE",
+                                         description: "The placeholder line to be excluded in stamped section and added to [Unreleased] section",
+                                         is_string: true,
+                                         optional: true)
         ]
       end
 

--- a/spec/fixtures/CHANGELOG_MOCK_UNRELEASED.md
+++ b/spec/fixtures/CHANGELOG_MOCK_UNRELEASED.md
@@ -1,0 +1,119 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning](http://semver.org/).
+
+## [Unreleased]
+### Added
+- New awesome feature
+
+## [0.3.0] - 2015-12-03
+### Added
+- RU translation from @aishek.
+- pt-BR translation from @tallesl.
+- es-ES translation from @ZeliosAriex.
+
+## [0.2.0] - 2015-10-06
+### Changed
+- Remove exclusionary mentions of "open source" since this project can benefit
+both "open" and "closed" source projects equally.
+
+## [0.1.0] - 2015-10-06
+### Added
+- Answer "Should you ever rewrite a change log?".
+
+### Changed
+- Improve argument against commit logs.
+- Start following [SemVer](http://semver.org) properly.
+
+## [0.0.8] - 2015-02-17
+### Changed
+- Update year to match in every README example.
+- Reluctantly stop making fun of Brits only, since most of the world
+  writes dates in a strange way.
+
+### Fixed
+- Fix typos in recent README changes.
+- Update outdated unreleased diff link.
+
+## [0.0.7] - 2015-02-16
+### Added
+- Link, and make it obvious that date format is ISO 8601.
+
+### Changed
+- Clarified the section on "Is there a standard change log format?".
+
+### Fixed
+- Fix Markdown links to tag comparison URL with footnote-style links.
+
+## [0.0.6] - 2014-12-12
+### Added
+- New awesome feature
+
+### Changed
+- Onboarding flow
+
+### Fixed
+- Fix Markdown links
+
+### Removed
+- User tracking
+
+### Work In Progress
+- Sales screen
+
+### Security
+- Enable SSL pinning
+
+### Deprecated
+- Obsolete contact screen
+
+## [0.0.5 (rc1)] - 2014-08-09
+### Added
+- Markdown links to version tags on release headings.
+- Unreleased section to gather unreleased changes and encourage note
+keeping prior to releases.
+
+## [0.0.4] - 2014-08-09
+### Added
+- Better explanation of the difference between the file ("CHANGELOG")
+and its function "the change log".
+
+### Changed
+- Refer to a "change log" instead of a "CHANGELOG" throughout the site
+to differentiate between the file and the purpose of the file — the
+logging of changes.
+
+### Removed
+- Remove empty sections from CHANGELOG, they occupy too much space and
+create too much noise in the file. People will have to assume that the
+missing sections were intentionally left out because they contained no
+notable changes.
+
+## [0.0.3] - 2014-08-09
+### Added
+- "Why should I care?" section mentioning The Changelog podcast.
+
+## [0.0.2] - 2014-07-10
+### Added
+- Explanation of the recommended reverse chronological release ordering.
+
+## [0.0.1] - 2014-05-31
+### Added
+- This CHANGELOG file to hopefully serve as an evolving example of a standardized open source project CHANGELOG.
+- CNAME file to enable GitHub Pages custom domain
+- README now contains answers to common questions about CHANGELOGs
+- Good examples and basic guidelines, including proper date formatting.
+- Counter-examples: "What makes unicorns cry?"
+
+[0.0.1]: https://github.com/olivierlacan/keep-a-changelog/compare/...v0.0.1
+[0.0.2]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.1...v0.0.2
+[0.0.3]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.2...v0.0.3
+[0.0.4]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.3...v0.0.4
+[0.0.5]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.4...v0.0.5
+[0.0.6]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.5...v0.0.6
+[0.0.7]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.6...v0.0.7
+[0.0.8]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.7...v0.0.8
+[0.1.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.8...v0.1.0
+[0.2.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.1.0...v0.2.0
+[0.3.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.2.0...v0.3.0
+[Unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.3.0...HEAD

--- a/spec/stamp_changelog_action_spec.rb
+++ b/spec/stamp_changelog_action_spec.rb
@@ -2,14 +2,18 @@ describe Fastlane::Actions::StampChangelogAction do
   describe 'Stamp CHANGELOG.md action' do
     let (:changelog_mock_path) { './../spec/fixtures/CHANGELOG_MOCK.md' }
     let (:changelog_mock_path_hook) { './spec/fixtures/CHANGELOG_MOCK.md' }
+    let (:changelog_mock_unreleased_path) { './../spec/fixtures/CHANGELOG_MOCK_UNRELEASED.md' }
+    let (:changelog_mock_unreleased_path_hook) { './spec/fixtures/CHANGELOG_MOCK_UNRELEASED.md' }
     let (:updated_section_identifier) { '12.34.56' }
 
     before(:each) do
       @original_content = File.read(changelog_mock_path_hook)
+      @original_content_unreleased = File.read(changelog_mock_unreleased_path_hook)
     end
 
     after(:each) do
       File.open(changelog_mock_path_hook, 'w') { |f| f.write(@original_content) }
+      File.open(changelog_mock_unreleased_path_hook, 'w') { |f| f.write(@original_content_unreleased) }
     end
 
     it 'stamps [Unreleased] section with given identifier' do
@@ -74,6 +78,18 @@ describe Fastlane::Actions::StampChangelogAction do
 
       modified_file = File.read(changelog_mock_path_hook)
       expect(modified_file.lines.last).to eq("[12.34.56]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.3.0...v12.34.56\n")
+    end
+
+    it 'creates tags comparion GitHub link with prefix working with [Unreleased] identifiers' do
+      # Stamp [Unreleased] with given section identifier
+      Fastlane::FastFile.new.parse("lane :test do
+          stamp_changelog(changelog_path: '#{changelog_mock_unreleased_path}',
+                          section_identifier: '#{updated_section_identifier}',
+                          git_tag: 'v#{updated_section_identifier}')
+          end").runner.execute(:test)
+
+      modified_file = File.read(changelog_mock_unreleased_path_hook)
+      expect(modified_file.lines.last).to eq("[Unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v12.34.56...HEAD\n")
     end
   end
 end


### PR DESCRIPTION
This adds the support for gitlab in diff links at the bottom of CHANGELOG.md

It also adds the support of `[Unreleased]` tags, with a reference to HEAD (both for github and bitbucket), to see the diff between last tag and current HEAD

I added a test for the [Unreleased] tag, but not for gitlab. Will work on this in a future  pull request.