### PR TITLE
improvements on StampChangelogAction

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ before_script:
   - bundle exec rake
 language: ruby
 rvm:
-  - 2.2
+  - 2.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+
+## [0.13.0] - 2019-02-26
 ### Fixed: 
 - Fixed `append_date` parameter of `update_changelog` action ([Issue #40](https://github.com/pajapro/fastlane-plugin-changelog/issues/40))
 
@@ -85,3 +87,4 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 [0.9.0]: https://github.com/pajapro/fastlane-plugin-changelog/compare/v0.8.0...v0.9.0
 [0.10.0]: https://github.com/pajapro/fastlane-plugin-changelog/compare/v0.9.0...v0.10.0
 [0.12.0]: https://github.com/pajapro/fastlane-plugin-changelog/compare/v0.10.0...v0.12.0
+[0.13.0]: https://github.com/pajapro/fastlane-plugin-changelog/compare/v0.12.0...v0.13.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed: 
+- Fixed `append_date` parameter of `update_changelog` action ([Issue #40](https://github.com/pajapro/fastlane-plugin-changelog/issues/40))
 
 ## [0.12.0] - 2018-11-16
 ### Fixed:

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ Additionally, you can provide an optional `git_tag` param, specifing git tag ass
 ``` ruby
 stamp_changelog(
   section_identifier: 'Build XYZ', # Specify identifier to stamp the Unreleased section with 
-  git_tag: 'bXYZ' # Specify reference to git tag associated with this section
+  git_tag: 'bXYZ', # Specify reference to git tag associated with this section
+  stamp_date: true # Specify whether current date should be appended to stamped section line (default is `true`)
 )
 ```
 

--- a/lib/fastlane/plugin/changelog/actions/stamp_changelog.rb
+++ b/lib/fastlane/plugin/changelog/actions/stamp_changelog.rb
@@ -78,7 +78,7 @@ module Fastlane
           end
 
           # Replace section identifier
-          previous_section_identifier = /(?<=\[)[^]]+(?=\]:)/.match(last_line)
+          previous_section_identifier = /(?<=\[)[^\]]+(?=\]:)/.match(last_line)
           last_line.sub!("[#{previous_section_identifier}]:", "[#{section_identifier}]:")
 
           # Replace first tag

--- a/lib/fastlane/plugin/changelog/actions/update_changelog.rb
+++ b/lib/fastlane/plugin/changelog/actions/update_changelog.rb
@@ -118,6 +118,7 @@ module Fastlane
                                        env_name: "FL_UPDATE_CHANGELOG_APPEND_DATE",
                                        description: "Appends the current date in YYYY-MM-DD format after the section identifier",
                                        default_value: true,
+                                       is_string: false,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :excluded_placeholder_line,
                                        env_name: "FL_UPDATE_CHANGELOG_EXCLUDED_PLACEHOLDER_LINE",

--- a/lib/fastlane/plugin/changelog/version.rb
+++ b/lib/fastlane/plugin/changelog/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Changelog
-    VERSION = "0.12.0"
+    VERSION = "0.13.0"
   end
 end

--- a/spec/fixtures/CHANGELOG_MOCK_BITBUCKET.md
+++ b/spec/fixtures/CHANGELOG_MOCK_BITBUCKET.md
@@ -1,0 +1,118 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning](http://semver.org/).
+
+## [Unreleased]
+### Added
+- New awesome feature
+
+## [0.3.0] - 2015-12-03
+### Added
+- RU translation from @aishek.
+- pt-BR translation from @tallesl.
+- es-ES translation from @ZeliosAriex.
+
+## [0.2.0] - 2015-10-06
+### Changed
+- Remove exclusionary mentions of "open source" since this project can benefit
+both "open" and "closed" source projects equally.
+
+## [0.1.0] - 2015-10-06
+### Added
+- Answer "Should you ever rewrite a change log?".
+
+### Changed
+- Improve argument against commit logs.
+- Start following [SemVer](http://semver.org) properly.
+
+## [0.0.8] - 2015-02-17
+### Changed
+- Update year to match in every README example.
+- Reluctantly stop making fun of Brits only, since most of the world
+  writes dates in a strange way.
+
+### Fixed
+- Fix typos in recent README changes.
+- Update outdated unreleased diff link.
+
+## [0.0.7] - 2015-02-16
+### Added
+- Link, and make it obvious that date format is ISO 8601.
+
+### Changed
+- Clarified the section on "Is there a standard change log format?".
+
+### Fixed
+- Fix Markdown links to tag comparison URL with footnote-style links.
+
+## [0.0.6] - 2014-12-12
+### Added
+- New awesome feature
+
+### Changed
+- Onboarding flow
+
+### Fixed
+- Fix Markdown links
+
+### Removed
+- User tracking
+
+### Work In Progress
+- Sales screen
+
+### Security
+- Enable SSL pinning
+
+### Deprecated
+- Obsolete contact screen
+
+## [0.0.5 (rc1)] - 2014-08-09
+### Added
+- Markdown links to version tags on release headings.
+- Unreleased section to gather unreleased changes and encourage note
+keeping prior to releases.
+
+## [0.0.4] - 2014-08-09
+### Added
+- Better explanation of the difference between the file ("CHANGELOG")
+and its function "the change log".
+
+### Changed
+- Refer to a "change log" instead of a "CHANGELOG" throughout the site
+to differentiate between the file and the purpose of the file — the
+logging of changes.
+
+### Removed
+- Remove empty sections from CHANGELOG, they occupy too much space and
+create too much noise in the file. People will have to assume that the
+missing sections were intentionally left out because they contained no
+notable changes.
+
+## [0.0.3] - 2014-08-09
+### Added
+- "Why should I care?" section mentioning The Changelog podcast.
+
+## [0.0.2] - 2014-07-10
+### Added
+- Explanation of the recommended reverse chronological release ordering.
+
+## [0.0.1] - 2014-05-31
+### Added
+- This CHANGELOG file to hopefully serve as an evolving example of a standardized open source project CHANGELOG.
+- CNAME file to enable GitHub Pages custom domain
+- README now contains answers to common questions about CHANGELOGs
+- Good examples and basic guidelines, including proper date formatting.
+- Counter-examples: "What makes unicorns cry?"
+
+[0.0.1]: https://bitbucket.org/repo/keep-a-changelog/branches/compare/...v0.0.1
+[0.0.2]: https://bitbucket.org/repo/keep-a-changelog/branches/compare/v0.0.2..v0.0.1
+[0.0.3]: https://bitbucket.org/repo/keep-a-changelog/branches/compare/v0.0.3..v0.0.2
+[0.0.4]: https://bitbucket.org/repo/keep-a-changelog/branches/compare/v0.0.4..v0.0.3
+[0.0.5]: https://bitbucket.org/repo/keep-a-changelog/branches/compare/v0.0.5..v0.0.4
+[0.0.6]: https://bitbucket.org/repo/keep-a-changelog/branches/compare/v0.0.6..v0.0.5
+[0.0.7]: https://bitbucket.org/repo/keep-a-changelog/branches/compare/v0.0.7..v0.0.6
+[0.0.8]: https://bitbucket.org/repo/keep-a-changelog/branches/compare/v0.0.8..v0.0.7
+[0.1.0]: https://bitbucket.org/repo/keep-a-changelog/branches/compare/v0.1.0..v0.0.8
+[0.2.0]: https://bitbucket.org/repo/keep-a-changelog/branches/compare/v0.2.0..v0.1.0
+[0.3.0]: https://bitbucket.org/repo/keep-a-changelog/branches/compare/v0.3.0..v0.2.0

--- a/spec/stamp_changelog_action_with_bitbucket_spec.rb
+++ b/spec/stamp_changelog_action_with_bitbucket_spec.rb
@@ -1,0 +1,48 @@
+describe Fastlane::Actions::StampChangelogAction do
+  describe 'Stamp CHANGELOG.md action with Bitbucket repo' do
+    let (:changelog_mock_path) { './../spec/fixtures/CHANGELOG_MOCK_BITBUCKET.md' }
+    let (:changelog_mock_path_hook) { './spec/fixtures/CHANGELOG_MOCK_BITBUCKET.md' }
+    let (:updated_section_identifier) { '12.34.56' }
+
+    before(:each) do
+      @original_content = File.read(changelog_mock_path_hook)
+    end
+
+    after(:each) do
+      File.open(changelog_mock_path_hook, 'w') { |f| f.write(@original_content) }
+    end
+
+    it 'use correct identifier when stamping [Unreleased] section' do
+      # Read what's in [Unreleased]
+      read_result = Fastlane::FastFile.new.parse("lane :test do
+          read_changelog(changelog_path: '#{changelog_mock_path}')
+        end").runner.execute(:test)
+
+      pre_stamp_file = File.read(changelog_mock_path_hook)
+      expect(pre_stamp_file).not_to include("## [#{updated_section_identifier}]")
+
+      # Stamp [Unreleased] with given section identifier
+      Fastlane::FastFile.new.parse("lane :test do
+       	stamp_changelog(changelog_path: '#{changelog_mock_path}',
+                         section_identifier: '#{updated_section_identifier}')
+     	end").runner.execute(:test)
+
+      # Read post-stamp file
+      post_stamp_file = File.read(changelog_mock_path_hook)
+
+      expect(post_stamp_file).to include("## [#{updated_section_identifier}]")
+    end
+
+    it 'creates reversed tags comparison for Bitbucket links' do
+      # Stamp [Unreleased] with given section identifier
+      Fastlane::FastFile.new.parse("lane :test do
+          stamp_changelog(changelog_path: '#{changelog_mock_path}',
+                          section_identifier: '#{updated_section_identifier}',
+                          git_tag: 'v#{updated_section_identifier}')
+          end").runner.execute(:test)
+
+      post_stamp_file = File.read(changelog_mock_path_hook)
+      expect(post_stamp_file.lines.last).to eq("[12.34.56]: https://bitbucket.org/repo/keep-a-changelog/branches/compare/v12.34.56..v0.3.0\n")
+    end
+  end
+end

--- a/spec/update_changelog_action_spec.rb
+++ b/spec/update_changelog_action_spec.rb
@@ -56,5 +56,52 @@ describe Fastlane::Actions::UpdateChangelogAction do
 
       expect(read_result).to eq(post_update_read_result)
     end
+
+    it 'updates [Unreleased] section identifier without appending date' do
+      # Update [Unreleased] section identifier with new one
+      Fastlane::FastFile.new.parse("lane :test do
+        update_changelog(changelog_path: '#{changelog_mock_path}',
+                          updated_section_identifier: '#{updated_section_identifier}',
+                          append_date: false)
+      end").runner.execute(:test)
+
+      # Read updated section line
+      modifiedSectionLine = ""
+      File.open(changelog_mock_path_hook, "r") do |file|
+        file.each_line do |line|
+            if line =~ /\#{2}\s?\[#{updated_section_identifier}\]/
+              modifiedSectionLine = line
+            break
+          end
+        end
+      end
+
+      # Expect the modified section line to be without date
+      expect(modifiedSectionLine).to eq("## [12.34.56]\n")
+    end
+
+    it 'updates [Unreleased] section identifier with appending date' do 
+      # Update [Unreleased] section identifier with new one
+      Fastlane::FastFile.new.parse("lane :test do
+        update_changelog(changelog_path: '#{changelog_mock_path}',
+                          updated_section_identifier: '#{updated_section_identifier}',
+                          append_date: true)
+      end").runner.execute(:test)
+
+      # Read updated section line
+      modifiedSectionLine = ""
+      File.open(changelog_mock_path_hook, "r") do |file|
+        file.each_line do |line|
+            if line =~ /\#{2}\s?\[#{updated_section_identifier}\]/
+              modifiedSectionLine = line
+            break
+          end
+        end
+      end
+
+      # Expect the modified section line to be with current date
+      now = Time.now.strftime("%Y-%m-%d")
+      expect(modifiedSectionLine).to eq("## [12.34.56] - #{now}\n")
+    end
   end
 end


### PR DESCRIPTION
- Stamps section identifier with version instead of git tag
- Reverses order of tags in diff link for bitbucket links

In my case, version and git tags were in the following format: 
[1.5.0.12.beta]: https://bitbucket.org/.../compare/v.1.5.0.12.beta..v.1.5.0.10.beta
[1.5.0.13.beta]: https://bitbucket.org/.../compare/v.1.5.0.13.beta..v.1.5.0.12.beta
[1.6.0.14.beta]: https://bitbucket.org/.../compare/v.1.6.0.14.beta..v.1.5.0.13.beta

When applying a stamp with version: 1.6.0.15.beta and git_tag: v.1.6.0.15.beta the changelog should look like: 
[1.5.0.12.beta]: https://bitbucket.org/.../compare/v.1.5.0.12.beta..v.1.5.0.10.beta
[1.5.0.13.beta]: https://bitbucket.org/.../compare/v.1.5.0.13.beta..v.1.5.0.12.beta
[1.6.0.14.beta]: https://bitbucket.org/.../compare/v.1.6.0.14.beta..v.1.5.0.13.beta
[1.6.0.15.beta]: https://bitbucket.org/.../compare/v.1.6.0.15.beta..v.1.5.0.14.beta

