### PR TITLE
Fix append date param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed: 
+- Fixed `append_date` parameter of `update_changelog` action ([Issue #40](https://github.com/pajapro/fastlane-plugin-changelog/issues/40))
 
 ## [0.12.0] - 2018-11-16
 ### Fixed:

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ Additionally, you can provide an optional `git_tag` param, specifing git tag ass
 ``` ruby
 stamp_changelog(
   section_identifier: 'Build XYZ', # Specify identifier to stamp the Unreleased section with 
-  git_tag: 'bXYZ' # Specify reference to git tag associated with this section
+  git_tag: 'bXYZ', # Specify reference to git tag associated with this section
+  stamp_date: true # Specify whether current date should be appended to stamped section line (default is `true`)
 )
 ```
 

--- a/lib/fastlane/plugin/changelog/actions/update_changelog.rb
+++ b/lib/fastlane/plugin/changelog/actions/update_changelog.rb
@@ -118,6 +118,7 @@ module Fastlane
                                        env_name: "FL_UPDATE_CHANGELOG_APPEND_DATE",
                                        description: "Appends the current date in YYYY-MM-DD format after the section identifier",
                                        default_value: true,
+                                       is_string: false,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :excluded_placeholder_line,
                                        env_name: "FL_UPDATE_CHANGELOG_EXCLUDED_PLACEHOLDER_LINE",

--- a/spec/update_changelog_action_spec.rb
+++ b/spec/update_changelog_action_spec.rb
@@ -56,5 +56,52 @@ describe Fastlane::Actions::UpdateChangelogAction do
 
       expect(read_result).to eq(post_update_read_result)
     end
+
+    it 'updates [Unreleased] section identifier without appending date' do
+      # Update [Unreleased] section identifier with new one
+      Fastlane::FastFile.new.parse("lane :test do
+        update_changelog(changelog_path: '#{changelog_mock_path}',
+                          updated_section_identifier: '#{updated_section_identifier}',
+                          append_date: false)
+      end").runner.execute(:test)
+
+      # Read updated section line
+      modifiedSectionLine = ""
+      File.open(changelog_mock_path_hook, "r") do |file|
+        file.each_line do |line|
+            if line =~ /\#{2}\s?\[#{updated_section_identifier}\]/
+              modifiedSectionLine = line
+            break
+          end
+        end
+      end
+
+      # Expect the modified section line to be without date
+      expect(modifiedSectionLine).to eq("## [12.34.56]\n")
+    end
+
+    it 'updates [Unreleased] section identifier with appending date' do 
+      # Update [Unreleased] section identifier with new one
+      Fastlane::FastFile.new.parse("lane :test do
+        update_changelog(changelog_path: '#{changelog_mock_path}',
+                          updated_section_identifier: '#{updated_section_identifier}',
+                          append_date: true)
+      end").runner.execute(:test)
+
+      # Read updated section line
+      modifiedSectionLine = ""
+      File.open(changelog_mock_path_hook, "r") do |file|
+        file.each_line do |line|
+            if line =~ /\#{2}\s?\[#{updated_section_identifier}\]/
+              modifiedSectionLine = line
+            break
+          end
+        end
+      end
+
+      # Expect the modified section line to be with current date
+      now = Time.now.strftime("%Y-%m-%d")
+      expect(modifiedSectionLine).to eq("## [12.34.56] - #{now}\n")
+    end
   end
 end


### PR DESCRIPTION
Fixes `append_date` parameter in `update_changelog` action, see issue https://github.com/pajapro/fastlane-plugin-changelog/issues/40 