### PR TITLE
Improved emojify_changelog design for posting on slack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,18 +5,22 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added:
 - Missing documentation to read_changelog and emojify_changelog actions ([PR #42](https://github.com/pajapro/fastlane-plugin-changelog/pull/42))
+
+### Changed
+- Design of emojify_changelog to support slack message formatting ([PR #43](https://github.com/pajapro/fastlane-plugin-changelog/pull/43))
+
 ## [0.14.0] - 2019-03-11
-### Added: 
+### Added:
 - Support for reversed order of tags in diff link for Bitbucket links ([PR #39](https://github.com/pajapro/fastlane-plugin-changelog/pull/39))
 - Support for stamping section identifier with _version_ instead of _git tag_ ([PR #39](https://github.com/pajapro/fastlane-plugin-changelog/pull/39))
 
 ## [0.13.0] - 2019-02-26
-### Fixed: 
+### Fixed:
 - Fixed `append_date` parameter of `update_changelog` action ([Issue #40](https://github.com/pajapro/fastlane-plugin-changelog/issues/40))
 
 ## [0.12.0] - 2018-11-16
 ### Fixed:
-- Bug when creating git tags comparison link ([Issue #32](https://github.com/pajapro/fastlane-plugin-changelog/issues/32)) 
+- Bug when creating git tags comparison link ([Issue #32](https://github.com/pajapro/fastlane-plugin-changelog/issues/32))
 
 ## [0.10.0] - 2018-11-11
 ### Fixed:

--- a/lib/fastlane/plugin/changelog/actions/emojify_changelog.rb
+++ b/lib/fastlane/plugin/changelog/actions/emojify_changelog.rb
@@ -28,14 +28,14 @@ module Fastlane
 
           if SUBSECTION_IDENTIFIERS.include?(stripped)
             emojified_string = case stripped
-                               when 'Added' then 'Added 🎁'
-                               when 'Changed' then 'Changed ↔️'
-                               when 'Fixed' then 'Fixed ✅'
-                               when 'Removed' then 'Removed 🚫'
-                               when 'Work In Progress' then 'Work In Progress 🚧'
-                               when 'Security' then 'Security 🔒'
-                               when 'Deprecated' then 'Deprecated 💨'
-                               end
+                                when 'Added' then '*Added* 🎁'
+                                when 'Changed' then '*Changed* ↔️'
+                                when 'Fixed' then '*Fixed* ✅'
+                                when 'Removed' then '*Removed* 🚫'
+                                when 'Work In Progress' then '*Work In Progress* 🚧'
+                                when 'Security' then '*Security* 🔒'
+                                when 'Deprecated' then '*Deprecated* 💨'
+                              end
 
             # Add back trailing colon, if previously removed
             if chopped_colon
@@ -49,6 +49,10 @@ module Fastlane
             emojified_content.concat(emojified_string)
           else
             # Output updated line
+            # Replace '-' with '*'
+            if line.start_with?('-')
+              line[0] = '•'
+            end
             emojified_content.concat(line)
           end
         end

--- a/spec/emojify_changelog_action_spec.rb
+++ b/spec/emojify_changelog_action_spec.rb
@@ -10,7 +10,7 @@ describe Fastlane::Actions::EmojifyChangelogAction do
         emojify_changelog
      	end").runner.execute(:test)
 
-      expect(result).to eq("Added 🎁\n- New awesome feature\n\nChanged ↔️\n- Onboarding flow\n\nFixed ✅\n- Fix Markdown links\n\nRemoved 🚫\n- User tracking\n\nWork In Progress 🚧\n- Sales screen\n\nSecurity 🔒\n- Enable SSL pinning\n\nDeprecated 💨\n- Obsolete contact screen")
+      expect(result).to eq("*Added* 🎁\n• New awesome feature\n\n*Changed* ↔️\n• Onboarding flow\n\n*Fixed* ✅\n• Fix Markdown links\n\n*Removed* 🚫\n• User tracking\n\n*Work In Progress* 🚧\n• Sales screen\n\n*Security* 🔒\n• Enable SSL pinning\n\n*Deprecated* 💨\n• Obsolete contact screen")
     end
   end
 end


### PR DESCRIPTION
1. Added *bold* wrapper around header names
2. Added •bullets at the beginning of every comment