### PR TITLE
Add new :append_datetime param and fix dates to UTC.

### DIFF
--- a/lib/fastlane/plugin/changelog/actions/stamp_changelog.rb
+++ b/lib/fastlane/plugin/changelog/actions/stamp_changelog.rb
@@ -14,22 +14,20 @@ module Fastlane
           UI.important("WARNING: No changes in [Unreleased] section to stamp!")
         else
           section_identifier = params[:section_identifier] unless params[:section_identifier].to_s.empty?
-          stamp_date_time = params[:stamp_date_time]
-          stamp_date = params[:stamp_date_time] ? false : params[:stamp_date]
+          stamp_datetime_format = params[:stamp_datetime_format]
           git_tag = params[:git_tag]
           placeholder_line = params[:placeholder_line]
 
-          stamp(changelog_path, section_identifier, stamp_date, stamp_date_time, git_tag, placeholder_line)
+          stamp(changelog_path, section_identifier, stamp_datetime_format, git_tag, placeholder_line)
         end
       end
 
-      def self.stamp(changelog_path, section_identifier, stamp_date, stamp_date_time, git_tag, placeholder_line)
+      def self.stamp(changelog_path, section_identifier, stamp_datetime_format, git_tag, placeholder_line)
         # 1. Update [Unreleased] section with given identifier
         Actions::UpdateChangelogAction.run(changelog_path: changelog_path,
                                           section_identifier: UNRELEASED_IDENTIFIER,
                                           updated_section_identifier: section_identifier,
-                                          append_date: stamp_date,
-                                          append_date_time: stamp_date_time,
+                                          append_datetime_format: stamp_datetime_format,
                                           excluded_placeholder_line: placeholder_line)
 
         file_content = ""
@@ -131,17 +129,11 @@ module Fastlane
                                        env_name: "FL_STAMP_CHANGELOG_SECTION_IDENTIFIER",
                                        description: "The unique section identifier to stamp the [Unreleased] section with",
                                        is_string: true),
-          FastlaneCore::ConfigItem.new(key: :stamp_date,
-                                       env_name: "FL_STAMP_CHANGELOG_SECTION_STAMP_DATE",
-                                       description: "Specifies whether the current UTC date should be appended to section identifier",
-                                       default_value: true,
-                                       is_string: false,
-                                       optional: true),
-          FastlaneCore::ConfigItem.new(key: :stamp_date_time,
-                                       env_name: "FL_STAMP_CHANGELOG_SECTION_STAMP_DATE_TIME",
-                                       description: "Specifies whether the current UTC date and time should be appended to section identifier",
-                                       default_value: false,
-                                       is_string: false,
+          FastlaneCore::ConfigItem.new(key: :stamp_datetime_format,
+                                       env_name: "FL_STAMP_CHANGELOG_DATETIME_FORMAT",
+                                       description: "The strftime format string to use for the date in the stamped section",
+                                       default_value: '%FZ',
+                                       is_string: true,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :git_tag,
                                        env_name: "FL_STAMP_CHANGELOG_GIT_TAG",

--- a/lib/fastlane/plugin/changelog/actions/stamp_changelog.rb
+++ b/lib/fastlane/plugin/changelog/actions/stamp_changelog.rb
@@ -14,19 +14,21 @@ module Fastlane
           UI.important("WARNING: No changes in [Unreleased] section to stamp!")
         else
           section_identifier = params[:section_identifier] unless params[:section_identifier].to_s.empty?
+          should_stamp_date = params[:should_stamp_date]
           stamp_datetime_format = params[:stamp_datetime_format]
           git_tag = params[:git_tag]
           placeholder_line = params[:placeholder_line]
 
-          stamp(changelog_path, section_identifier, stamp_datetime_format, git_tag, placeholder_line)
+          stamp(changelog_path, section_identifier, should_stamp_date, stamp_datetime_format, git_tag, placeholder_line)
         end
       end
 
-      def self.stamp(changelog_path, section_identifier, stamp_datetime_format, git_tag, placeholder_line)
+      def self.stamp(changelog_path, section_identifier, should_stamp_date, stamp_datetime_format, git_tag, placeholder_line)
         # 1. Update [Unreleased] section with given identifier
         Actions::UpdateChangelogAction.run(changelog_path: changelog_path,
                                           section_identifier: UNRELEASED_IDENTIFIER,
                                           updated_section_identifier: section_identifier,
+                                          should_append_date: should_stamp_date,
                                           append_datetime_format: stamp_datetime_format,
                                           excluded_placeholder_line: placeholder_line)
 
@@ -129,6 +131,12 @@ module Fastlane
                                        env_name: "FL_STAMP_CHANGELOG_SECTION_IDENTIFIER",
                                        description: "The unique section identifier to stamp the [Unreleased] section with",
                                        is_string: true),
+          FastlaneCore::ConfigItem.new(key: :should_stamp_date,
+                                       env_name: "FL_STAMP_CHANGELOG_SHOULD_STAMP_DATE",
+                                       description: "Specifies whether the current date as per the stamp_datetime_format should be stamped to the section identifier",
+                                       default_value: true,
+                                       is_string: false,
+                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :stamp_datetime_format,
                                        env_name: "FL_STAMP_CHANGELOG_DATETIME_FORMAT",
                                        description: "The strftime format string to use for the date in the stamped section",

--- a/lib/fastlane/plugin/changelog/actions/stamp_changelog.rb
+++ b/lib/fastlane/plugin/changelog/actions/stamp_changelog.rb
@@ -14,20 +14,22 @@ module Fastlane
           UI.important("WARNING: No changes in [Unreleased] section to stamp!")
         else
           section_identifier = params[:section_identifier] unless params[:section_identifier].to_s.empty?
-          stamp_date = params[:stamp_date]
+          stamp_date_time = params[:stamp_date_time]
+          stamp_date = params[:stamp_date_time] ? false : params[:stamp_date]
           git_tag = params[:git_tag]
           placeholder_line = params[:placeholder_line]
 
-          stamp(changelog_path, section_identifier, stamp_date, git_tag, placeholder_line)
+          stamp(changelog_path, section_identifier, stamp_date, stamp_date_time, git_tag, placeholder_line)
         end
       end
 
-      def self.stamp(changelog_path, section_identifier, stamp_date, git_tag, placeholder_line)
+      def self.stamp(changelog_path, section_identifier, stamp_date, stamp_date_time, git_tag, placeholder_line)
         # 1. Update [Unreleased] section with given identifier
         Actions::UpdateChangelogAction.run(changelog_path: changelog_path,
                                           section_identifier: UNRELEASED_IDENTIFIER,
                                           updated_section_identifier: section_identifier,
                                           append_date: stamp_date,
+                                          append_date_time: stamp_date_time,
                                           excluded_placeholder_line: placeholder_line)
 
         file_content = ""
@@ -131,8 +133,15 @@ module Fastlane
                                        is_string: true),
           FastlaneCore::ConfigItem.new(key: :stamp_date,
                                        env_name: "FL_STAMP_CHANGELOG_SECTION_STAMP_DATE",
-                                       description: "Specifies whether the current date should be appended to section identifier",
+                                       description: "Specifies whether the current UTC date should be appended to section identifier",
                                        default_value: true,
+                                       is_string: false,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :stamp_date_time,
+                                       env_name: "FL_STAMP_CHANGELOG_SECTION_STAMP_DATE_TIME",
+                                       description: "Specifies whether the current UTC date and time should be appended to section identifier",
+                                       default_value: false,
+                                       is_string: false,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :git_tag,
                                        env_name: "FL_STAMP_CHANGELOG_GIT_TAG",

--- a/lib/fastlane/plugin/changelog/actions/update_changelog.rb
+++ b/lib/fastlane/plugin/changelog/actions/update_changelog.rb
@@ -48,14 +48,11 @@ module Fastlane
               line_old = line.dup
               line.sub!(section_name, new_section_identifier)
 
-              if params[:append_date_time] || params[:append_date]
-                if params[:append_date_time]
-                  now = Time.now.utc.iso8601
-                  ENV["FL_UPDATE_APPEND_DATE_TIME_VAL"] = now
-                else
-                  now = Time.now.utc.strftime("%Y-%m-%d")
-                  ENV["FL_UPDATE_APPEND_DATE_VAL"] = now
-                end
+              append_datetime_format = params[:append_datetime_format]
+
+              if append_datetime_format
+                now = Time.now.utc.strftime(append_datetime_format)
+                ENV["FL_UPDATE_APPEND_DATETIME_VAL"] = now
 
                 line.concat(" - " + now)
                 line.delete!(line_separator) # remove line break, because concatenation adds line break between section identifer & date
@@ -121,17 +118,11 @@ module Fastlane
                                        description: "The updated unique section identifier (without square brackets)",
                                        is_string: true,
                                        optional: true),
-          FastlaneCore::ConfigItem.new(key: :append_date,
-                                       env_name: "FL_UPDATE_CHANGELOG_APPEND_DATE",
-                                       description: "Appends the current UTC date in YYYY-MM-DD format after the section identifier",
-                                       default_value: true,
-                                       is_string: false,
-                                       optional: true),
-          FastlaneCore::ConfigItem.new(key: :append_date_time,
-                                       env_name: "FL_UPDATE_CHANGELOG_APPEND_DATE_TIME",
-                                       description: "Appends the current UTC date in YYYY-MM-DDTHH:MM:SSZ format after the section identifier",
-                                       default_value: false,
-                                       is_string: false,
+          FastlaneCore::ConfigItem.new(key: :append_datetime_format,
+                                       env_name: "FL_UPDATE_CHANGELOG_APPEND_DATETIME_FORMAT",
+                                       description: "The strftime format string to use for the date after the section identifier",
+                                       default_value: '%FZ',
+                                       is_string: true,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :excluded_placeholder_line,
                                        env_name: "FL_UPDATE_CHANGELOG_EXCLUDED_PLACEHOLDER_LINE",

--- a/lib/fastlane/plugin/changelog/actions/update_changelog.rb
+++ b/lib/fastlane/plugin/changelog/actions/update_changelog.rb
@@ -48,8 +48,15 @@ module Fastlane
               line_old = line.dup
               line.sub!(section_name, new_section_identifier)
 
-              if params[:append_date]
-                now = Time.now.strftime("%Y-%m-%d")
+              if params[:append_date_time] || params[:append_date]
+                if params[:append_date_time]
+                  now = Time.now.utc.iso8601
+                  ENV["FL_UPDATE_APPEND_DATE_TIME_VAL"] = now
+                else
+                  now = Time.now.utc.strftime("%Y-%m-%d")
+                  ENV["FL_UPDATE_APPEND_DATE_VAL"] = now
+                end
+
                 line.concat(" - " + now)
                 line.delete!(line_separator) # remove line break, because concatenation adds line break between section identifer & date
                 line.concat(line_separator) # add line break to the end of the string, in order to start next line on the next line
@@ -116,8 +123,14 @@ module Fastlane
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :append_date,
                                        env_name: "FL_UPDATE_CHANGELOG_APPEND_DATE",
-                                       description: "Appends the current date in YYYY-MM-DD format after the section identifier",
+                                       description: "Appends the current UTC date in YYYY-MM-DD format after the section identifier",
                                        default_value: true,
+                                       is_string: false,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :append_date_time,
+                                       env_name: "FL_UPDATE_CHANGELOG_APPEND_DATE_TIME",
+                                       description: "Appends the current UTC date in YYYY-MM-DDTHH:MM:SSZ format after the section identifier",
+                                       default_value: false,
                                        is_string: false,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :excluded_placeholder_line,

--- a/lib/fastlane/plugin/changelog/actions/update_changelog.rb
+++ b/lib/fastlane/plugin/changelog/actions/update_changelog.rb
@@ -48,9 +48,11 @@ module Fastlane
               line_old = line.dup
               line.sub!(section_name, new_section_identifier)
 
-              append_datetime_format = params[:append_datetime_format]
+              should_append_date = params[:should_append_date]
 
-              if append_datetime_format
+              if should_append_date
+                append_datetime_format = params[:append_datetime_format]
+
                 now = Time.now.utc.strftime(append_datetime_format)
                 ENV["FL_UPDATE_APPEND_DATETIME_VAL"] = now
 
@@ -117,6 +119,12 @@ module Fastlane
                                        env_name: "FL_UPDATE_CHANGELOG_UPDATED_SECTION_IDENTIFIER",
                                        description: "The updated unique section identifier (without square brackets)",
                                        is_string: true,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :should_append_date,
+                                       env_name: "FL_UPDATE_CHANGELOG_SHOULD_APPEND_DATE",
+                                       description: "Specifies whether the current date as per the append_datetime_format should be appended to section identifier",
+                                       default_value: true,
+                                       is_string: false,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :append_datetime_format,
                                        env_name: "FL_UPDATE_CHANGELOG_APPEND_DATETIME_FORMAT",

--- a/lib/fastlane/plugin/changelog/version.rb
+++ b/lib/fastlane/plugin/changelog/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Changelog
-    VERSION = "0.15.0"
+    VERSION = "0.15.1"
   end
 end

--- a/spec/update_changelog_action_spec.rb
+++ b/spec/update_changelog_action_spec.rb
@@ -62,7 +62,7 @@ describe Fastlane::Actions::UpdateChangelogAction do
       Fastlane::FastFile.new.parse("lane :test do
         update_changelog(changelog_path: '#{changelog_mock_path}',
                           updated_section_identifier: '#{updated_section_identifier}',
-                          append_datetime_format: nil)
+                          should_append_date: false)
       end").runner.execute(:test)
 
       # Read updated section line

--- a/spec/update_changelog_action_spec.rb
+++ b/spec/update_changelog_action_spec.rb
@@ -57,12 +57,12 @@ describe Fastlane::Actions::UpdateChangelogAction do
       expect(read_result).to eq(post_update_read_result)
     end
 
-    it 'updates [Unreleased] section identifier without appending date' do
-      # Update [Unreleased] section identifier with new one
+    it 'updates [Unreleased] section identifier without appending a date' do
+      # Update [Unreleased] section identifier with new one - explicitly ask to not use a date.
       Fastlane::FastFile.new.parse("lane :test do
         update_changelog(changelog_path: '#{changelog_mock_path}',
                           updated_section_identifier: '#{updated_section_identifier}',
-                          append_date: false)
+                          append_datetime_format: nil)
       end").runner.execute(:test)
 
       # Read updated section line
@@ -80,12 +80,11 @@ describe Fastlane::Actions::UpdateChangelogAction do
       expect(modifiedSectionLine).to eq("## [12.34.56]\n")
     end
 
-    it 'updates [Unreleased] section identifier with appending date' do 
-      # Update [Unreleased] section identifier with new one
+    it 'updates [Unreleased] section identifier appending a date via the default datetime format' do
+      # Update [Unreleased] section identifier with new one via the default datetime format
       Fastlane::FastFile.new.parse("lane :test do
         update_changelog(changelog_path: '#{changelog_mock_path}',
-                          updated_section_identifier: '#{updated_section_identifier}',
-                          append_date: true)
+                         updated_section_identifier: '#{updated_section_identifier}')
       end").runner.execute(:test)
 
       # Read updated section line
@@ -100,7 +99,31 @@ describe Fastlane::Actions::UpdateChangelogAction do
       end
 
       # Expect the modified section line to be with current date
-      now = Time.now.strftime("%Y-%m-%d")
+      now = Time.now.utc.strftime("%FZ")
+      expect(modifiedSectionLine).to eq("## [12.34.56] - #{now}\n")
+    end
+
+    it 'updates [Unreleased] section identifier appending a date via a user specified datetime format' do
+      # Update [Unreleased] section identifier with new one via the user specified datetime format
+      Fastlane::FastFile.new.parse("lane :test do
+        update_changelog(changelog_path: '#{changelog_mock_path}',
+                          updated_section_identifier: '#{updated_section_identifier}',
+                          append_datetime_format: '%FT%TZ')
+      end").runner.execute(:test)
+
+      # Read updated section line
+      modifiedSectionLine = ""
+      File.open(changelog_mock_path_hook, "r") do |file|
+        file.each_line do |line|
+            if line =~ /\#{2}\s?\[#{updated_section_identifier}\]/
+              modifiedSectionLine = line
+            break
+          end
+        end
+      end
+
+      # Expect the modified section line to be with current date
+      now = Time.now.utc.strftime("%FT%TZ")
       expect(modifiedSectionLine).to eq("## [12.34.56] - #{now}\n")
     end
   end


### PR DESCRIPTION
This PR adds a new stamp_changelog action argument: `stamp_date_time`. Specifying true stamps the changelog in the format of standard iso8601 date time `"2020-12-17T22:25:13Z"`. By default it is false and when true it overrides stamp_date. The date chosen, whether by specifying `stamp_date: true` or `stamp_date_time: true` are placed in the env variable `FL_UPDATE_DATE_VAL`, `FL_UPDATE_DATE_TIME_VAL` respectively.


It also fixes the error being given by fastlane that the stamp_date arg was not a string and makes all the dates used for the stamp_dates be in UTC time.

 I figure this PR may require some additional modifications depending on the needs of the project but I figured it could be built upon 😄.